### PR TITLE
TK-99-prefix-routes-api

### DIFF
--- a/src/main/java/fr/lunatech/timekeeper/resources/ActivityResource.java
+++ b/src/main/java/fr/lunatech/timekeeper/resources/ActivityResource.java
@@ -8,7 +8,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("/activities")
+@Path("/api/activities")
 public class ActivityResource {
 
     @Inject
@@ -22,7 +22,7 @@ public class ActivityResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("{id}")
+    @Path("/{id}")
     public ActivityDto readActivityById(@PathParam("id") long id) {
         return activityService.getActivityById(id).orElseThrow(NotFoundException::new);
     }

--- a/src/main/java/fr/lunatech/timekeeper/resources/CustomerResource.java
+++ b/src/main/java/fr/lunatech/timekeeper/resources/CustomerResource.java
@@ -9,7 +9,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
-@Path("/customers")
+@Path("/api/customers")
 public class CustomerResource {
 
     @Inject
@@ -29,7 +29,7 @@ public class CustomerResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("{id}")
+    @Path("/{id}")
     public CustomerDto readCustomerById(@PathParam("id") long id) {
         return customerService.getCustomerById(id).orElseThrow(NotFoundException::new);
     }
@@ -37,7 +37,7 @@ public class CustomerResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("{id}")
+    @Path("/{id}")
     public Response updateCustomer(@PathParam("id") long id, CustomerDto customerDto){
         return Response.ok(customerService.updateCustomer(id, customerDto)).build();
     }

--- a/src/main/java/fr/lunatech/timekeeper/resources/ExampleResource.java
+++ b/src/main/java/fr/lunatech/timekeeper/resources/ExampleResource.java
@@ -14,7 +14,7 @@ import javax.ws.rs.core.MediaType;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
 // Ce petit endpoint est pratique pour tester rapidement si Quarkus est bien démarré.
-@Path("/hello")
+@Path("/api/hello")
 public class ExampleResource {
     private static final Logger logger = LoggerFactory.getLogger(ExampleResource.class);
 

--- a/src/main/java/fr/lunatech/timekeeper/resources/MemberResource.java
+++ b/src/main/java/fr/lunatech/timekeeper/resources/MemberResource.java
@@ -8,7 +8,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("/members")
+@Path("/api/members")
 public class MemberResource {
 
     @Inject
@@ -22,7 +22,7 @@ public class MemberResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("{id}")
+    @Path("/{id}")
     public MemberDto readActivityById(@PathParam("id") long id) {
         return userTkService.getMemberById(id).orElseThrow(NotFoundException::new);
     }

--- a/src/main/java/fr/lunatech/timekeeper/resources/UserTkResource.java
+++ b/src/main/java/fr/lunatech/timekeeper/resources/UserTkResource.java
@@ -8,7 +8,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("/users")
+@Path("/api/tkusers")
 public class UserTkResource {
 
     @Inject
@@ -22,7 +22,7 @@ public class UserTkResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Path("{id}")
+    @Path("/{id}")
     public UserTkDto readActivityById(@PathParam("id") long id) {
         return userTkService.getUserTkById(id).orElseThrow(NotFoundException::new);
     }

--- a/src/test/java/fr/lunatech/timekeeper/resources/ActivityResourceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/resources/ActivityResourceTest.java
@@ -31,17 +31,17 @@ class ActivityResourceTest {
     @Test
     public void testPostActivityResourcesEndpoint() {
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/customers")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/api/customers")
                 .then()
                 .statusCode(200).body(is("1"));
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"Pepito\",\"billale\":true,\"description\":\"New project\", \"customerId\":1, \"members\":[]}").post("/activities")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"Pepito\",\"billale\":true,\"description\":\"New project\", \"customerId\":1, \"members\":[]}").post("/api/activities")
                 .then()
                 .statusCode(200).body(is("2"));
 
         given()
-                .when().get("/activities/2")
+                .when().get("/api/activities/2")
                 .then()
                 .statusCode(200)
                 .body(is("{\"billale\":true,\"customerId\":1,\"id\":2,\"members\":[],\"name\":\"Pepito\"}"));
@@ -51,27 +51,27 @@ class ActivityResourceTest {
     public void testPostActivityResourcesWithMemberValidEndpoint() {
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"firstname\":\"Sam\",\"lastname\":\"Huel\",\"email\":\"sam@gmail.com\", \"profile\":\"Admin\"}").post("/users")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"firstname\":\"Sam\",\"lastname\":\"Huel\",\"email\":\"sam@gmail.com\", \"profile\":\"Admin\"}").post("/api/tkusers")
                 .then()
                 .statusCode(200).body(is("1"));
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"role\":\"Developer\", \"userId\":1}").post("/members")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"role\":\"Developer\", \"userId\":1}").post("/api/members")
                 .then()
                 .statusCode(200).body(is("2"));
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/customers")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/api/customers")
                 .then()
                 .statusCode(200).body(is("3"));
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"Pepito\",\"billale\":true,\"description\":\"New project\", \"customerId\":3, \"members\":[2]}").post("/activities")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"Pepito\",\"billale\":true,\"description\":\"New project\", \"customerId\":3, \"members\":[2]}").post("/api/activities")
                 .then()
                 .statusCode(200).body(is("4"));
 
         given()
-                .when().get("/activities/4")
+                .when().get("/api/activities/4")
                 .then()
                 .statusCode(200)
                 .body(is("{\"billale\":true,\"customerId\":3,\"id\":4,\"members\":[2],\"name\":\"Pepito\"}"));
@@ -81,7 +81,7 @@ class ActivityResourceTest {
     public void testPostActivityResourcesWithWrongCustomerIdEndpoint() {
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"Pepito\",\"billale\":true,\"description\":\"New project\", \"customerId\":10, \"members\":[]}").post("/activities")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"Pepito\",\"billale\":true,\"description\":\"New project\", \"customerId\":10, \"members\":[]}").post("/api/activities")
                 .then()
                 .statusCode(400);
 
@@ -91,12 +91,12 @@ class ActivityResourceTest {
     @Test
     public void testPostActivityResourcesWithWrongMemberIdEndpoint() {
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/customers")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/api/customers")
                 .then()
                 .statusCode(200).body(is("1"));
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"Pepito\",\"billale\":true,\"description\":\"New project\", \"customerId\":1, \"members\":[1,2]}").post("/activities")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"Pepito\",\"billale\":true,\"description\":\"New project\", \"customerId\":1, \"members\":[1,2]}").post("/api/activities")
                 .then()
                 .statusCode(400);
 
@@ -106,7 +106,7 @@ class ActivityResourceTest {
     @Test
     public void testGetUnExistedActivityResourceEndpoint() {
         given()
-                .when().get("/activities/4")
+                .when().get("/api/activities/4")
                 .then()
                 .statusCode(404);
 

--- a/src/test/java/fr/lunatech/timekeeper/resources/CustomerResourceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/resources/CustomerResourceTest.java
@@ -31,12 +31,12 @@ class CustomerResourceTest {
     @Test
     public void testPostCustomerResourcesWithOutActivitiesEndpoint() {
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/customers")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/api/customers")
                 .then()
                 .statusCode(200);
 
         given()
-                .when().get("/customers/1")
+                .when().get("/api/customers/1")
                 .then()
                 .statusCode(200)
                 .body(is("{\"activitiesId\":[],\"id\":1,\"name\":\"NewClient\"}"));
@@ -45,7 +45,7 @@ class CustomerResourceTest {
     @Test
     public void testGetUnExistedCustomerResourceEndpoint() {
         given()
-                .when().get("/customers/4")
+                .when().get("/api/customers/4")
                 .then()
                 .statusCode(404);
     }
@@ -53,17 +53,17 @@ class CustomerResourceTest {
     @Test
     public void testGetAllCustomersWithOutActivitiesEndpoint() {
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/customers")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/api/customers")
                 .then()
                 .statusCode(200);
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient2\"}").post("/customers")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient2\"}").post("/api/customers")
                 .then()
                 .statusCode(200);
 
         given()
-                .when().get("/customers")
+                .when().get("/api/customers")
                 .then()
                 .statusCode(200)
                 .body(is("[{\"activitiesId\":[],\"id\":1,\"name\":\"NewClient\"},{\"activitiesId\":[],\"id\":2,\"name\":\"NewClient2\"}]"));
@@ -73,7 +73,7 @@ class CustomerResourceTest {
     public void testGetAllCustomersWithOutCustomerAndWithOutActivitiesEndpoint() {
 
         given()
-                .when().get("/customers")
+                .when().get("/api/customers")
                 .then()
                 .statusCode(200)
                 .body(is("[]"));
@@ -83,18 +83,18 @@ class CustomerResourceTest {
     public void testUpdateCustomerWithOutActivitiesEndpoint(){
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/customers")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"name\":\"NewClient\"}").post("/api/customers")
                 .then()
                 .statusCode(200);
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"activitiesId\":[],\"id\":1,\"name\":\"NewName\"}").put("/customers/1")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"activitiesId\":[],\"id\":1,\"name\":\"NewName\"}").put("/api/customers/1")
                 .then()
                 .statusCode(200)
                 .body(is("1"));
 
         given()
-                .when().get("/customers/1")
+                .when().get("/api/customers/1")
                 .then()
                 .statusCode(200)
                 .body(is("{\"activitiesId\":[],\"id\":1,\"name\":\"NewName\"}"));

--- a/src/test/java/fr/lunatech/timekeeper/resources/MemberResourceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/resources/MemberResourceTest.java
@@ -32,17 +32,17 @@ class MemberResourceTest {
     public void testPosMemberResourcesEndpoint() {
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"firstname\":\"Sam\",\"lastname\":\"Huel\",\"email\":\"sam@gmail.com\", \"profile\":\"Admin\"}").post("/users")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"firstname\":\"Sam\",\"lastname\":\"Huel\",\"email\":\"sam@gmail.com\", \"profile\":\"Admin\"}").post("/api/tkusers")
                 .then()
                 .statusCode(200).body(is("1"));
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"role\":\"Developer\", \"userId\":1}").post("/members")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"role\":\"Developer\", \"userId\":1}").post("/api/members")
                 .then()
                 .statusCode(200).body(is("2"));
 
         given()
-                .when().get("/members/2")
+                .when().get("/api/members/2")
                 .then()
                 .statusCode(200)
                 .body(is("{\"id\":2,\"role\":\"Developer\",\"userId\":1}"));
@@ -52,7 +52,7 @@ class MemberResourceTest {
     public void testPosMemberResourcesWithWrongUserIdEndpoint() {
 
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"role\":\"Developer\", \"userId\":12}").post("/members")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"role\":\"Developer\", \"userId\":12}").post("/api/members")
                 .then()
                 .statusCode(400);
     }
@@ -60,7 +60,7 @@ class MemberResourceTest {
     @Test
     public void testGetUnExistedMemberResourceEndpoint() {
         given()
-                .when().get("/members/4")
+                .when().get("/api/members/4")
                 .then()
                 .statusCode(404);
 

--- a/src/test/java/fr/lunatech/timekeeper/resources/UserTkResourceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/resources/UserTkResourceTest.java
@@ -31,12 +31,12 @@ class UserTkResourceTest {
     @Test
     public void testPostUserTkResourcesEndpoint() {
         given()
-                .when().contentType(MediaType.APPLICATION_JSON).body("{\"firstname\":\"Sam\",\"lastname\":\"Huel\",\"email\":\"sam@gmail.com\", \"profile\":\"Admin\"}").post("/users")
+                .when().contentType(MediaType.APPLICATION_JSON).body("{\"firstname\":\"Sam\",\"lastname\":\"Huel\",\"email\":\"sam@gmail.com\", \"profile\":\"Admin\"}").post("/api/tkusers")
                 .then()
                 .statusCode(200).body(is("1"));
 
         given()
-                .when().get("/users/1")
+                .when().get("/api/tkusers/1")
                 .then()
                 .statusCode(200)
                 .body(is("{\"email\":\"sam@gmail.com\",\"id\":1,\"lastname\":\"Huel\",\"profile\":\"Admin\"}"));
@@ -45,7 +45,7 @@ class UserTkResourceTest {
     @Test
     public void testGetUnExistedUserResourceEndpoint() {
         given()
-                .when().get("/users/4")
+                .when().get("/api/tkusers/4")
                 .then()
                 .statusCode(404);
 


### PR DESCRIPTION
prefix all restEasy routes by /api to avoid conflicts with the embedded front framework