### PR TITLE
npm lint -> npm run lint

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -57,11 +57,11 @@ You will also see any lint errors in the console.
 Launches the test runner in the interactive watch mode.<br />
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
-### `npm lint`
+### `npm run lint`
 
 Launches the ESLint code check
 
-### `npm lint-fix`
+### `npm run lint-fix`
 
 Launches the ESLint code check and fix simple typos, tabs, semi-colon, etc.
 


### PR DESCRIPTION
In my environment and @GuillaumeDavy 's environment, `npm lint` doesn't  work.
Was it a mistake ?
npm lint -> npm run lint