### PR TITLE
The sidebar is selected even in the other pages than entity's list

### DIFF
--- a/frontend/src/components/MenuSidebar/MenuSidebar.js
+++ b/frontend/src/components/MenuSidebar/MenuSidebar.js
@@ -10,8 +10,10 @@ import FolderOpenOutlined from '@ant-design/icons/lib/icons/FolderOpenOutlined';
 class MenuSidebar extends Component {
   render() {
     const {location} = this.props;
+    const splitPathname = location.pathname.split('/').filter(i=>i);
+    const selectedKeys = splitPathname.length === 0 ? [] : ['/' + splitPathname[0]];
     return (
-      <Menu id="tk_Menu" defaultSelectedKeys={['/home']} mode="inline" selectedKeys={[location.pathname]} theme="dark">
+      <Menu id="tk_Menu" defaultSelectedKeys={['/home']} mode="inline" selectedKeys={selectedKeys} theme="dark">
         <Menu.Item className="tk_MenuItem" key="/home">
           <Link to="/home">
             <PieChartOutlined/>


### PR DESCRIPTION
The sidebar wasn't selected when the location was different than '/entity'.