### PR TITLE
Remove the Copyright header to avoid Flyway checksum errors on the pre-prod env

### DIFF
--- a/src/main/resources/db/migration/V10__time_entry_remove_billable.sql
+++ b/src/main/resources/db/migration/V10__time_entry_remove_billable.sql
@@ -1,18 +1,2 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 ALTER TABLE public.timeentries drop column billable;
 ALTER TABLE public.user_events add eventType varchar(255) null;

--- a/src/main/resources/db/migration/V11__user_events_event_template.sql
+++ b/src/main/resources/db/migration/V11__user_events_event_template.sql
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 DROP TABLE IF EXISTS user_events;
 DROP TABLE IF EXISTS event_template;
 

--- a/src/main/resources/db/migration/V12__add_version_to_entities.sql
+++ b/src/main/resources/db/migration/V12__add_version_to_entities.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Lunatech S.A.S
+ * Copyright 2020 Lunatech Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/db/migration/V13__revert_event_template_user_events_join_table.sql
+++ b/src/main/resources/db/migration/V13__revert_event_template_user_events_join_table.sql
@@ -1,17 +1,1 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 DROP TABLE IF EXISTS event_template_user_events ;

--- a/src/main/resources/db/migration/V14__update_enum_profile.sql
+++ b/src/main/resources/db/migration/V14__update_enum_profile.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Lunatech S.A.S
+ * Copyright 2020 Lunatech Labs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 create sequence public.hibernate_sequence;
 
 create table public.clients

--- a/src/main/resources/db/migration/V2__user_picture.sql
+++ b/src/main/resources/db/migration/V2__user_picture.sql
@@ -1,18 +1,2 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 ALTER TABLE public.users
     ADD picture varchar(255)

--- a/src/main/resources/db/migration/V3__add_organisation_entity.sql
+++ b/src/main/resources/db/migration/V3__add_organisation_entity.sql
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 CREATE TABLE public.organizations (
 	id int8 NOT NULL,
 	name varchar(255) NULL,

--- a/src/main/resources/db/migration/V4__public_access.sql
+++ b/src/main/resources/db/migration/V4__public_access.sql
@@ -1,18 +1,2 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 ALTER TABLE public.projects
     ADD publicaccess bool

--- a/src/main/resources/db/migration/V5__init2.sql
+++ b/src/main/resources/db/migration/V5__init2.sql
@@ -1,18 +1,3 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 drop table public.clients cascade;
 drop table public.projects cascade;

--- a/src/main/resources/db/migration/V6__organization_token_unique.sql
+++ b/src/main/resources/db/migration/V6__organization_token_unique.sql
@@ -1,17 +1,1 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 ALTER TABLE organizations ADD CONSTRAINT uk_organizations_tokenname UNIQUE (tokenname);

--- a/src/main/resources/db/migration/V7__client_organization.sql
+++ b/src/main/resources/db/migration/V7__client_organization.sql
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 ALTER TABLE clients add organization_id int8 not null;
 
 ALTER TABLE clients ADD constraint fk_clients_organization_id foreign KEY (organization_id) REFERENCES organizations (id);

--- a/src/main/resources/db/migration/V8__creation_timesheet.sql
+++ b/src/main/resources/db/migration/V8__creation_timesheet.sql
@@ -1,19 +1,3 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 DROP TABLE IF EXISTS timesheets_time_entry CASCADE ;
 DROP TABLE IF EXISTS time_entry CASCADE ;
 DROP TABLE IF EXISTS timesheets CASCADE ;

--- a/src/main/resources/db/migration/V9__new_schema.sql
+++ b/src/main/resources/db/migration/V9__new_schema.sql
@@ -1,18 +1,3 @@
-/*
- * Copyright 2020 Lunatech S.A.S
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 drop table IF EXISTS projects_users cascade;
 drop table IF EXISTS user_events cascade;


### PR DESCRIPTION
We cannot add the Copyright header to past SQL scripts that are already deployed on ‘acceptance’ as it would generate an error with Flyway…