### PR TITLE
TK-451-Disable day's details for public holidays

### DIFF
--- a/frontend/src/components/TimeSheet/WeekCalendar.js
+++ b/frontend/src/components/TimeSheet/WeekCalendar.js
@@ -33,7 +33,7 @@ import {
   renderRangeWithYear,
   weekRangeOfDate,
   totalHoursPerDay,
-  isPublicHoliday,
+  isPublicHoliday, isNotWeekEnd, isNotPublicHoliday,
 } from '../../utils/momentUtils';
 import moment from 'moment';
 import _ from 'lodash';
@@ -185,7 +185,7 @@ const WeekCalendar = (props) => {
             }
           };
           const renderUserEvents = (userEvents) => {
-            if(userEvents && item && !isWeekEnd(item.date) && !isPublicHoliday(item.date,publicHolidays)){
+            if(userEvents && item && isNotWeekEnd(item.date) && isNotPublicHoliday(item.date,publicHolidays)){
               return userEvents.map(userEvent => {
                 return userEvent.eventUserDaysResponse.map(userEventDay => {
                   if(userEventDay.date === item.date.format('YYYY-MM-DD')){

--- a/frontend/src/pages/TimeSheet/timeEntriesPage.js
+++ b/frontend/src/pages/TimeSheet/timeEntriesPage.js
@@ -28,7 +28,7 @@ import TimeEntryForm from '../../components/TimeEntry/TimeEntryForm';
 import UserTimeSheetList from '../../components/TimeSheet/UserTimeSheetList';
 import MonthCalendar from '../../components/TimeSheet/MonthCalendar';
 import CalendarSelectionMode from '../../components/TimeSheet/CalendarSelectionMode';
-import {getIsoMonth, isNotWeekEnd} from '../../utils/momentUtils';
+import {getIsoMonth, isNotPublicHoliday, isNotWeekEnd} from '../../utils/momentUtils';
 
 //https://stackoverflow.com/questions/14446511/most-efficient-method-to-groupby-on-an-array-of-objects/34890276#34890276
 const groupBy = function (xs, key) {
@@ -151,7 +151,7 @@ const TimeEntriesPage = () => {
   };
 
   const onClickCard = (e, m) => {
-    if(isNotWeekEnd(m)){
+    if(isNotWeekEnd(m) && isNotPublicHoliday(m, publicHolidays)){
       setTaskMoment(m);
       setViewMode();
       openModal();

--- a/frontend/src/utils/momentUtils.js
+++ b/frontend/src/utils/momentUtils.js
@@ -143,6 +143,9 @@ export const isWeekEnd = (date) => date.isoWeekday() === 6 || date.isoWeekday() 
 //Returns false if the date is saturday or sunday
 export const isNotWeekEnd = (date) => !isWeekEnd(date);
 
+//Returns false if the date is a public holiday
+export const isNotPublicHoliday = (date, publicHolidays) => !isPublicHoliday(date, publicHolidays);
+
 // Returns the number of hours between two dates
 export const computeNumberOfHours = (start, end) => {
   return moment.duration(end.diff(start)).asHours();

--- a/frontend/src/utils/momentUtils.test.js
+++ b/frontend/src/utils/momentUtils.test.js
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2020 Lunatech Labs
  *
@@ -14,7 +15,14 @@
  * limitations under the License.
  */
 
-import {renderRangeWithYear, renderRange, weekRangeOfDate, totalHoursPerDay} from './momentUtils';
+import {
+  renderRangeWithYear,
+  renderRange,
+  weekRangeOfDate,
+  totalHoursPerDay,
+  isPublicHoliday,
+  isNotPublicHoliday
+} from './momentUtils';
 import moment from 'moment';
 
 // eslint-disable-next-line
@@ -228,4 +236,60 @@ test('totalHoursPerDay should return 3 hours for 2 entries that overlaps each ot
   const result = totalHoursPerDay(emptyUserEvent,'2020-08-04',emptyEntries);
   // eslint-disable-next-line
   expect(result).toBe(3);
+});
+
+// eslint-disable-next-line
+test('isPublicHoliday should return true for 14th July', () =>{
+  const publicHolidays = [];
+  publicHolidays.push({
+    date:"2020-07-14",
+    localName: "",
+    name: "",
+    countryCode: "",
+  })
+  const result = isPublicHoliday(moment.utc('2020-07-14'),publicHolidays);
+  // eslint-disable-next-line
+  expect(result).toBe(true);
+});
+
+// eslint-disable-next-line
+test('isPublicHoliday should return false for 15th July', () =>{
+  const publicHolidays = [];
+  publicHolidays.push({
+    date:"2020-07-14",
+    localName: "",
+    name: "",
+    countryCode: "",
+  })
+  const result = isPublicHoliday(moment.utc('2020-07-15'),publicHolidays);
+  // eslint-disable-next-line
+  expect(result).toBe(false);
+});
+
+// eslint-disable-next-line
+test('isNotPublicHoliday should return false for 14th July', () =>{
+  const publicHolidays = [];
+  publicHolidays.push({
+    date:"2020-07-14",
+    localName: "",
+    name: "",
+    countryCode: "",
+  })
+  const result = isNotPublicHoliday(moment.utc('2020-07-14'),publicHolidays);
+  // eslint-disable-next-line
+  expect(result).toBe(false);
+});
+
+// eslint-disable-next-line
+test('isNotPublicHoliday should return true for 15th July', () =>{
+  const publicHolidays = [];
+  publicHolidays.push({
+    date:"2020-07-14",
+    localName: "",
+    name: "",
+    countryCode: "",
+  })
+  const result = isNotPublicHoliday(moment.utc('2020-07-15'),publicHolidays);
+  // eslint-disable-next-line
+  expect(result).toBe(true);
 });


### PR DESCRIPTION
Desired behavior : 

If the concerned day is a public holiday, the opening of detail of the day is not possible (same behavior as a week-end day)