### PR TITLE
Refacto on the JS part after startDateTime and endDateTime were removed

### DIFF
--- a/frontend/src/components/TimeEntry/AddEntryForm.js
+++ b/frontend/src/components/TimeEntry/AddEntryForm.js
@@ -119,6 +119,7 @@ const AddEntryForm = ({date, form, timeSheets, onSuccess, onCancel, numberOfHour
       >
         <TitleSection title='Add task'/>
         <Form.Item name="startDate" noStyle={true}>
+          <Input hidden={true}/>
         </Form.Item>
 
         <Form.Item label="Description:" name="comment" rules={[{required: true}]}>

--- a/frontend/src/components/TimeEntry/AddEntryForm.js
+++ b/frontend/src/components/TimeEntry/AddEntryForm.js
@@ -27,46 +27,34 @@ const {Option} = Select;
 const {TextArea} = Input;
 
 const initialValues = (defaultDate) => {
-  const start = defaultDate.clone();
-  start.set({
-    hour: 9,
-    minute: 0,
-    second: 0
-  });
   return {
     'comment': null,
     'timeSheetId': null,
-    'date': defaultDate,
-    'startDateTime': start, //9 am by default
+    'startDate': defaultDate,
+    'numberOfHours':1
   };
 };
 
 // Add the additional values
 // Use the values of the form or initialize the values
 const additionalValues = (timeUnit, defaultDate, allValues) => {
-  const start = defaultDate.clone();
-  start.set({
-    hour: 9,
-    minute: 0,
-    second: 0
-  });
   switch (timeUnit) {
     case 'DAY': {
       return {
-        'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': 8
+        'startDate': allValues.startDate,
+        'numberOfHours': 8
       };
     }
     case 'HALFDAY': {
       return {
-        'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': 4
+        'startDate': allValues.startDate,
+        'numberOfHours': 4
       };
     }
     case 'HOURLY' : {
       return {
-        'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': null
+        'startDate': allValues.startDate,
+        'numberOfHours': null
       };
     }
     default: {
@@ -107,11 +95,11 @@ const AddEntryForm = ({date, form, timeSheets, onSuccess, onCancel, numberOfHour
         setSelectedTimeSheet(timeSheet);
         const timeUnit = timeSheet ? timeSheet.timeUnit : '';
         form.setFieldsValue({timeUnit});
-        form.setFieldsValue(additionalValues(timeSheet.timeUnit, allValues.date, allValues));
+        form.setFieldsValue(additionalValues(timeSheet.timeUnit, allValues.startDate, allValues));
         break;
       }
       case 'timeUnit': {
-        form.setFieldsValue(additionalValues(changedValues.timeUnit, allValues.date, allValues));
+        form.setFieldsValue(additionalValues(changedValues.timeUnit, allValues.startDate, allValues));
         break;
       }
       default:
@@ -130,7 +118,7 @@ const AddEntryForm = ({date, form, timeSheets, onSuccess, onCancel, numberOfHour
         onValuesChange={onValuesChange}
       >
         <TitleSection title='Add task'/>
-        <Form.Item name="date" noStyle={true}>
+        <Form.Item name="startDate" noStyle={true}>
         </Form.Item>
 
         <Form.Item label="Description:" name="comment" rules={[{required: true}]}>
@@ -166,9 +154,6 @@ const AddEntryForm = ({date, form, timeSheets, onSuccess, onCancel, numberOfHour
             </Form.Item>
           </Col>
 
-          <Form.Item name="startDateTime" noStyle={true}>
-          </Form.Item>
-
           <Col className="gutter-row" span={9}>
             {/*Additional Values : depends on the Time Unit*/}
             <Form.Item shouldUpdate={(prevValues, curValues) => prevValues.timeUnit !== curValues.timeUnit}>
@@ -182,7 +167,7 @@ const AddEntryForm = ({date, form, timeSheets, onSuccess, onCancel, numberOfHour
                     );
                   default:
                     return (
-                      <Form.Item name="numberHours" noStyle={true}>
+                      <Form.Item name="numberOfHours" noStyle={true}>
                         <Input hidden={true}/>
                       </Form.Item>
                     );

--- a/frontend/src/components/TimeEntry/AddEntryForm.js
+++ b/frontend/src/components/TimeEntry/AddEntryForm.js
@@ -192,7 +192,7 @@ AddEntryForm.propTypes = {
   timeSheets: PropTypes.array.isRequired,
   onSuccess: PropTypes.func,
   onCancel: PropTypes.func,
-  numberOfHoursForDay: PropTypes.array
+  numberOfHoursForDay: PropTypes.number.isRequired
 };
 
 export default AddEntryForm;

--- a/frontend/src/components/TimeEntry/EditEntryForm.js
+++ b/frontend/src/components/TimeEntry/EditEntryForm.js
@@ -43,13 +43,12 @@ const initialValues = (defaultDate, entry, timeSheetId) => {
     startDate: moment.utc(entry.startDate),
     numberOfHours: entry.numberOfHours
   };
-  const numberOfHours = new Array(newEntry.numberOfHours);
   return {
     'comment': newEntry.comment,
     'timeSheetId': timeSheetId,
     'startDate': moment.utc(newEntry.startDate, 'YYYY-MM-DD'),
-    'timeUnit' : computeTimeUnit(numberOfHours),
-    'numberOfHours': numberOfHours
+    'timeUnit' : computeTimeUnit(entry.numberOfHours),
+    'numberOfHours': entry.numberOfHours
   };
 };
 

--- a/frontend/src/components/TimeEntry/EditEntryForm.js
+++ b/frontend/src/components/TimeEntry/EditEntryForm.js
@@ -20,7 +20,6 @@ import {Button, Col, Form, Input, message, Radio, Row, Select, Space} from 'antd
 import PropTypes from 'prop-types';
 import TitleSection from '../Title/TitleSection';
 import moment from 'moment';
-import {computeNumberOfHours} from '../../utils/momentUtils';
 import SelectHoursComponent from './SelectHoursComponent';
 import {isTimeSheetDisabled} from '../../utils/timesheetUtils';
 
@@ -180,26 +179,26 @@ const EditEntryForm = ({date, form, timeSheets, onSuccess, onCancel, entry, numb
             </Form.Item>
           </Col>
 
-          <Form.Item name='startDate' noStyle={true}>
+          <Form.Item name="startDate" noStyle={true}>
+            <Input hidden={true}/>
           </Form.Item>
 
           <Col className="gutter-row" span={9}>
             {/*Additional Values : depends on the Time Unit*/}
             <Form.Item shouldUpdate={(prevValues, curValues) => prevValues.timeUnit !== curValues.timeUnit}>
               {({getFieldValue}) => {
-                switch (getFieldValue('timeUnit')) {
-                  case 'HOURLY':
-                    return (
-                      <div>
-                        {<SelectHoursComponent numberOfHoursForDay={numberOfHoursForDay} entryDuration={entryDuration} />}
-                      </div>
-                    );
-                  default:
-                    return (
-                            <Form.Item name="numberOfHours" noStyle={true}>
-                        <Input hidden={true}/>
-                      </Form.Item>
-                    );
+                if (getFieldValue('timeUnit') === 'HOURLY') {
+                  return (
+                    <div>
+                      <SelectHoursComponent numberOfHoursForDay={numberOfHoursForDay} entryDuration={entryDuration} />
+                    </div>
+                  );
+                } else {
+                  return (
+                    <Form.Item name="numberOfHours" noStyle={true}>
+                      <Input hidden={true}/>
+                    </Form.Item>
+                  );
                 }
               }}
             </Form.Item>

--- a/frontend/src/components/TimeEntry/EditEntryForm.js
+++ b/frontend/src/components/TimeEntry/EditEntryForm.js
@@ -27,8 +27,8 @@ import {isTimeSheetDisabled} from '../../utils/timesheetUtils';
 const {Option} = Select;
 const {TextArea} = Input;
 
-const computeTimeUnit = (numberHours) => {
-  switch (numberHours) {
+const computeTimeUnit = (numberOfHours) => {
+  switch (numberOfHours) {
     case 4:
       return 'HALFDAY';
     case 8:
@@ -41,18 +41,16 @@ const computeTimeUnit = (numberHours) => {
 const initialValues = (defaultDate, entry, timeSheetId) => {
   const newEntry = {
     ...entry,
-    startDateTime: moment.utc(entry.startDateTime),
-    endDateTime: moment.utc(entry.endDateTime)
+    startDate: moment.utc(entry.startDate),
+    numberOfHours: entry.numberOfHours
   };
-  const numberOfHours = computeNumberOfHours(newEntry.startDateTime, newEntry.endDateTime);
+  const numberOfHours = new Array(newEntry.numberOfHours);
   return {
     'comment': newEntry.comment,
     'timeSheetId': timeSheetId,
-    'date': moment.utc(newEntry.startDateTime, 'YYYY-MM-DD'),
-    'startDateTime': newEntry.startDateTime,
-    'endDateTime': newEntry.endDateTime,
+    'startDate': moment.utc(newEntry.startDate, 'YYYY-MM-DD'),
     'timeUnit' : computeTimeUnit(numberOfHours),
-    'numberHours': numberOfHours
+    'numberOfHours': numberOfHours
   };
 };
 
@@ -60,20 +58,20 @@ const updatedValues = (timeUnit, allValues, start) => {
   switch (timeUnit) {
     case 'DAY': {
       return {
-        'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': 8
+        'startDate': allValues.startDate || start, //9 am by default
+        'numberOfHours': 8
       };
     }
     case 'HALFDAY': {
       return {
-        'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': 4
+        'startDate': allValues.startDate || start, //9 am by default
+        'numberOfHours': 4
       };
     }
     case 'HOURLY' : {
       return {
-        'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': null
+        'startDate': allValues.startDate || start, //9 am by default
+        'numberOfHours': null
       };
     }
     default: {
@@ -104,7 +102,7 @@ const EditEntryForm = ({date, form, timeSheets, onSuccess, onCancel, entry, numb
   const [entryUpdated, setEntryUpdated] = useState(false);
   const [selectedTimeSheet, setSelectedTimeSheet] = useState();
   const timeKeeperAPIPut = useTimeKeeperAPIPut(urlEdition(form, entry.id), (form => form), setEntryUpdated);
-  const entryDuration = computeNumberOfHours(moment.utc(entry.startDateTime), moment.utc(entry.endDateTime));
+  const entryDuration = entry.numberOfHours;
   useEffect(() => {
     if (entryUpdated) {
       message.success('Entry was updated');
@@ -153,8 +151,6 @@ const EditEntryForm = ({date, form, timeSheets, onSuccess, onCancel, entry, numb
         onValuesChange={onValuesChange}
       >
         <TitleSection title='Edit task'/>
-        <Form.Item name="date" noStyle={true}>
-        </Form.Item>
 
         <Form.Item label="Description:" name="comment" rules={[{required: true}]}>
           <TextArea rows={2} placeholder="What did you work on ?"/>
@@ -190,7 +186,7 @@ const EditEntryForm = ({date, form, timeSheets, onSuccess, onCancel, entry, numb
             </Form.Item>
           </Col>
 
-          <Form.Item name="startDateTime" noStyle={true}>
+          <Form.Item name="startDate" noStyle={true}>
           </Form.Item>
 
           <Col className="gutter-row" span={9}>
@@ -206,7 +202,7 @@ const EditEntryForm = ({date, form, timeSheets, onSuccess, onCancel, entry, numb
                     );
                   default:
                     return (
-                      <Form.Item name="numberHours" noStyle={true}>
+                      <Form.Item name="numberOfHours" noStyle={true}>
                         <Input hidden={true}/>
                       </Form.Item>
                     );
@@ -237,8 +233,8 @@ EditEntryForm.propTypes = {
     billable: PropTypes.bool,
     timeSheetId: PropTypes.number.isRequired,
     isMorning: PropTypes.bool.isRequired,
-    startDateTime: PropTypes.object.isRequired,
-    endDateTime: PropTypes.object.isRequired,
+    startDate: PropTypes.object.isRequired,
+    numberOfHours: PropTypes.number.isRequired
   }).isRequired,
   numberOfHoursForDay: PropTypes.array
 };

--- a/frontend/src/components/TimeEntry/EditEntryForm.js
+++ b/frontend/src/components/TimeEntry/EditEntryForm.js
@@ -54,23 +54,23 @@ const initialValues = (defaultDate, entry, timeSheetId) => {
   };
 };
 
-const updatedValues = (timeUnit, allValues, start) => {
+const updatedValues = (timeUnit, allValues) => {
   switch (timeUnit) {
     case 'DAY': {
       return {
-        'startDate': allValues.startDate || start, //9 am by default
+        'startDate': allValues.startDate,
         'numberOfHours': 8
       };
     }
     case 'HALFDAY': {
       return {
-        'startDate': allValues.startDate || start, //9 am by default
+        'startDate': allValues.startDate,
         'numberOfHours': 4
       };
     }
     case 'HOURLY' : {
       return {
-        'startDate': allValues.startDate || start, //9 am by default
+        'startDate': allValues.startDate,
         'numberOfHours': null
       };
     }
@@ -83,13 +83,7 @@ const updatedValues = (timeUnit, allValues, start) => {
 // Add the additional values
 // Use the values of the form or initialize the values
 const additionalValues = (timeUnit, defaultDate, allValues) => {
-  const start = defaultDate.clone();
-  start.set({
-    hour: 9,
-    minute: 0,
-    second: 0
-  });
-  return updatedValues(timeUnit, allValues, start);
+  return updatedValues(timeUnit, allValues);
 };
 
 // Compute the url
@@ -186,7 +180,7 @@ const EditEntryForm = ({date, form, timeSheets, onSuccess, onCancel, entry, numb
             </Form.Item>
           </Col>
 
-          <Form.Item name="startDate" noStyle={true}>
+          <Form.Item name='startDate' noStyle={true}>
           </Form.Item>
 
           <Col className="gutter-row" span={9}>
@@ -202,7 +196,7 @@ const EditEntryForm = ({date, form, timeSheets, onSuccess, onCancel, entry, numb
                     );
                   default:
                     return (
-                      <Form.Item name="numberOfHours" noStyle={true}>
+                            <Form.Item name="numberOfHours" noStyle={true}>
                         <Input hidden={true}/>
                       </Form.Item>
                     );
@@ -231,11 +225,9 @@ EditEntryForm.propTypes = {
     id: PropTypes.number.isRequired,
     comment: PropTypes.string.isRequired,
     billable: PropTypes.bool,
-    timeSheetId: PropTypes.number.isRequired,
-    isMorning: PropTypes.bool.isRequired,
-    startDate: PropTypes.object.isRequired,
+    startDate: PropTypes.string.isRequired,
     numberOfHours: PropTypes.number.isRequired
   }).isRequired,
-  numberOfHoursForDay: PropTypes.array
+  numberOfHoursForDay: PropTypes.number
 };
 export default EditEntryForm;

--- a/frontend/src/components/TimeEntry/SelectHoursComponent.js
+++ b/frontend/src/components/TimeEntry/SelectHoursComponent.js
@@ -24,7 +24,7 @@ const {Option} = Select;
 const SelectHoursComponent = ({numberOfHoursForDay, entryDuration}) => {
   const hourDisabled = (hour) => {
     if(entryDuration){
-      return parseInt(hour) + (numberOfHoursForDay - entryDuration) > 8;
+      return parseInt(hour) + (parseInt(numberOfHoursForDay) - entryDuration) > 8;
     }
     return parseInt(hour) + numberOfHoursForDay > 8;
   };

--- a/frontend/src/components/TimeEntry/SelectHoursComponent.js
+++ b/frontend/src/components/TimeEntry/SelectHoursComponent.js
@@ -24,9 +24,9 @@ const {Option} = Select;
 const SelectHoursComponent = ({numberOfHoursForDay, entryDuration}) => {
   const hourDisabled = (hour) => {
     if(entryDuration){
-      return parseInt(hour) + (parseInt(numberOfHoursForDay) - entryDuration) > 8;
+      return parseInt(hour) + (numberOfHoursForDay - entryDuration) > 8;
     }
-    return parseInt(hour) + parseInt(numberOfHoursForDay) > 8;
+    return parseInt(hour) + numberOfHoursForDay > 8;
   };
   return (
     <Form.Item name="numberOfHours" label="Number of hours:" rules={[{required: true}]}>
@@ -39,7 +39,7 @@ const SelectHoursComponent = ({numberOfHoursForDay, entryDuration}) => {
   );
 };
 SelectHoursComponent.propTypes = {
-  numberOfHoursForDay: PropTypes.array.isRequired,
+  numberOfHoursForDay: PropTypes.number.isRequired,
   entryDuration: PropTypes.number,
 };
 

--- a/frontend/src/components/TimeEntry/SelectHoursComponent.js
+++ b/frontend/src/components/TimeEntry/SelectHoursComponent.js
@@ -29,7 +29,7 @@ const SelectHoursComponent = ({numberOfHoursForDay, entryDuration}) => {
     return parseInt(hour) + parseInt(numberOfHoursForDay) > 8;
   };
   return (
-    <Form.Item name="numberHours" label="Number of hours:" rules={[{required: true}]}>
+    <Form.Item name="numberOfHours" label="Number of hours:" rules={[{required: true}]}>
       <Select
         showSearch
       >

--- a/frontend/src/components/TimeEntry/ShowTimeEntry.js
+++ b/frontend/src/components/TimeEntry/ShowTimeEntry.js
@@ -21,10 +21,7 @@ import {Button} from 'antd';
 import Tooltip from 'antd/lib/tooltip';
 import {ClockCircleOutlined, DeleteOutlined, CopyOutlined, EditOutlined} from '@ant-design/icons';
 
-const moment = require('moment');
-
 const ShowTimeEntry = ({entry, onClickEdit}) => {
-  const start = moment(entry.startDate).utc();
   const duration = entry.numberOfHours;
 
   return (

--- a/frontend/src/components/TimeEntry/ShowTimeEntry.js
+++ b/frontend/src/components/TimeEntry/ShowTimeEntry.js
@@ -24,14 +24,8 @@ import {ClockCircleOutlined, DeleteOutlined, CopyOutlined, EditOutlined} from '@
 const moment = require('moment');
 
 const ShowTimeEntry = ({entry, onClickEdit}) => {
-  const start = moment(entry.startDateTime).utc();
-  const end = moment(entry.endDateTime).utc();
-
-  const duration = moment.duration(end.diff(start));
-  const date = start.clone();
-  date.set({
-    hour: duration.asHours()
-  });
+  const start = moment(entry.startDate).utc();
+  const duration = entry.numberOfHours;
 
   return (
     <div className="tk_TaskInfoGen">
@@ -40,7 +34,7 @@ const ShowTimeEntry = ({entry, onClickEdit}) => {
         <div className="tk_TaskInfoMiddle">
           <div>
             <p>{entry.project ? entry.project.name : ''}</p>
-            <p><ClockCircleOutlined />{date.format('hh:mm')}</p>
+            <p><ClockCircleOutlined />{duration}</p>
           </div>
           <div>
             <Tooltip title="Edit" key="edit">
@@ -67,8 +61,8 @@ ShowTimeEntry.propTypes = {
     project: PropTypes.shape({
       name: PropTypes.string.isRequired,
     }).isRequired,
-    startDateTime: PropTypes.string.isRequired,
-    endDateTime: PropTypes.string.isRequired,
+    startDate: PropTypes.string.isRequired,
+    numberOfHours: PropTypes.number.isRequired
   }),
   onClickEdit: PropTypes.func.isRequired // () => set the mode to 'edit', the mode can be 'view', 'add' or 'edit'
 };

--- a/frontend/src/components/TimeEntry/TimeEntry.js
+++ b/frontend/src/components/TimeEntry/TimeEntry.js
@@ -19,7 +19,6 @@ import './TimeEntry.less';
 import {Badge} from 'antd';
 import {ClockCircleOutlined} from '@ant-design/icons';
 import PropTypes from 'prop-types';
-import {computeNumberOfHours} from '../../utils/momentUtils';
 import moment from 'moment';
 
 const computeSize = (nbHours) => {
@@ -28,7 +27,6 @@ const computeSize = (nbHours) => {
 };
 const TimeEntry = ({entry, onClick}) => {
   const start = moment(entry.startDate).utc();
-  const date = start.clone();
   const hours = entry.numberOfHours;
   const size = computeSize(hours);
   return (

--- a/frontend/src/components/TimeEntry/TimeEntry.js
+++ b/frontend/src/components/TimeEntry/TimeEntry.js
@@ -27,13 +27,9 @@ const computeSize = (nbHours) => {
   return minimumSize + (nbHours - 1) * 50;
 };
 const TimeEntry = ({entry, onClick}) => {
-  const start = moment(entry.startDateTime).utc();
-  const end = moment(entry.endDateTime).utc();
+  const start = moment(entry.startDate).utc();
   const date = start.clone();
-  const hours = computeNumberOfHours(start, end);
-  date.set({
-    hour: hours
-  });
+  const hours = entry.numberOfHours;
   const size = computeSize(hours);
   return (
     <div className="tk_TaskCard" style={{height: `${size}px`}}
@@ -45,7 +41,7 @@ const TimeEntry = ({entry, onClick}) => {
         />
         <p>{(entry && entry.project && entry.project.name) ? entry.project.name : ''}</p>
       </div>
-      <p><ClockCircleOutlined/>{date.format('hh:mm')}</p>
+      <p><ClockCircleOutlined/>{hours}</p>
     </div>
   );
 };
@@ -56,8 +52,8 @@ TimeEntry.propTypes = {
     project: PropTypes.shape({
       name: PropTypes.string.isRequired,
     }).isRequired,
-    startDateTime: PropTypes.string.isRequired,
-    endDateTime: PropTypes.string.isRequired,
+    startDate: PropTypes.string.isRequired,
+    numberOfHours: PropTypes.number.isRequired,
   }),
   onClick: PropTypes.func.isRequired
 };

--- a/frontend/src/components/TimeEntry/TimeEntryForm.js
+++ b/frontend/src/components/TimeEntry/TimeEntryForm.js
@@ -127,13 +127,7 @@ const TimeEntryForm = ({entries, userEvents, currentDay, form, onSuccess, onCanc
   };
   // Returns the number of hours for a day
   const amountOfHoursPerDay = (entriesArray, ue, date) => {
-      const resultToReturn = totalHoursPerDay(ue, date, entriesArray[0]);
-      console.log('amountOfHoursPerDay' + resultToReturn);
-      console.log(resultToReturn);
-      console.log(_.isArray(resultToReturn));
-      console.log(_.toArray(resultToReturn));
-
-    return resultToReturn;
+    return totalHoursPerDay(ue, date, entriesArray[0]);
   };
   return (
     <div className="tk_ModalGen">

--- a/frontend/src/components/TimeEntry/TimeEntryForm.js
+++ b/frontend/src/components/TimeEntry/TimeEntryForm.js
@@ -26,7 +26,6 @@ import EditEntryForm from './EditEntryForm';
 import UserEventCard from '../UserEvent/UserEventCard';
 import {totalHoursPerDay} from '../../utils/momentUtils';
 import {getMaximumHoursPerDay} from '../../utils/configUtils';
-import _ from 'lodash'; // important!
 const {TextArea} = Input;
 
 const TimeEntryForm = ({entries, userEvents, currentDay, form, onSuccess, onCancel, mode, setMode, selectedEntryId}) => {

--- a/frontend/src/components/TimeEntry/TimeEntryForm.js
+++ b/frontend/src/components/TimeEntry/TimeEntryForm.js
@@ -26,7 +26,7 @@ import EditEntryForm from './EditEntryForm';
 import UserEventCard from '../UserEvent/UserEventCard';
 import {totalHoursPerDay} from '../../utils/momentUtils';
 import {getMaximumHoursPerDay} from '../../utils/configUtils';
-
+import _ from 'lodash'; // important!
 const {TextArea} = Input;
 
 const TimeEntryForm = ({entries, userEvents, currentDay, form, onSuccess, onCancel, mode, setMode, selectedEntryId}) => {
@@ -114,8 +114,8 @@ const TimeEntryForm = ({entries, userEvents, currentDay, form, onSuccess, onCanc
     );
   };
   const UserEvents = ({userEvents, date}) => {
-    const showUserEvents = (userEvents) => {
-      return userEvents.map(userEvent => {
+    const showUserEvents = (userEvents2) => {
+      return userEvents2.map(userEvent => {
         return [...Array(userEvent.eventUserDaysResponse.length).keys()]
           .filter(i => date.format('YYYY-MM-DD') === userEvent.eventUserDaysResponse[i].date)
           .map(i => {
@@ -126,8 +126,14 @@ const TimeEntryForm = ({entries, userEvents, currentDay, form, onSuccess, onCanc
     return showUserEvents(userEvents);
   };
   // Returns the number of hours for a day
-  const amountOfHoursPerDay = (entriesArray, userEvents, date) => {
-    return totalHoursPerDay(userEvents, date, entriesArray[0]);
+  const amountOfHoursPerDay = (entriesArray, ue, date) => {
+      const resultToReturn = totalHoursPerDay(ue, date, entriesArray[0]);
+      console.log('amountOfHoursPerDay' + resultToReturn);
+      console.log(resultToReturn);
+      console.log(_.isArray(resultToReturn));
+      console.log(_.toArray(resultToReturn));
+
+    return resultToReturn;
   };
   return (
     <div className="tk_ModalGen">

--- a/frontend/src/pages/TimeSheet/timeEntriesPage.js
+++ b/frontend/src/pages/TimeSheet/timeEntriesPage.js
@@ -41,7 +41,7 @@ const groupBy = function (xs, key) {
 const computeData = (timeSheets) => Object.entries(groupBy(timeSheets.flatMap(({entries, project}) => entries.map(x => ({
   ...x,
   project
-}))), entry => moment(entry.startDateTime).format('YYYY-MM-DD'))).map(([key, value]) => {
+}))), entry => moment(entry.startDate).format('YYYY-MM-DD'))).map(([key, value]) => {
   return ({
     data: value,
     date: moment(key),

--- a/frontend/src/utils/momentUtils.js
+++ b/frontend/src/utils/momentUtils.js
@@ -106,10 +106,7 @@ const userEventsDurationPerDay = (userEvents, date) => {
 const timeEntriesDuration = (timeEntries) => {
   if(timeEntries){
     return _.sumBy(timeEntries, function(entry){
-      const start = moment(entry.startDateTime).utc();
-      const end = moment(entry.endDateTime).utc();
-      const duration = moment.duration(end.diff(start));
-      return duration.asHours();
+      return entry.numberOfHours;
     });
   }
   return 0;

--- a/src/main/java/fr/lunatech/timekeeper/gauges/TimeEntriesNumberPerHoursGauge.java
+++ b/src/main/java/fr/lunatech/timekeeper/gauges/TimeEntriesNumberPerHoursGauge.java
@@ -13,8 +13,8 @@ public class TimeEntriesNumberPerHoursGauge {
     private long eightHours;
     private long otherHours;
 
-    public void incrementGauges(Integer numberHours) {
-        switch (numberHours) {
+    public void incrementGauges(Integer numberOfHours) {
+        switch (numberOfHours) {
             case 4:
                 fourHours++;
                 break;
@@ -27,8 +27,8 @@ public class TimeEntriesNumberPerHoursGauge {
         }
     }
 
-    public void decrementGauges(Integer numberHours) {
-        switch (numberHours) {
+    public void decrementGauges(Integer numberOfHours) {
+        switch (numberOfHours) {
             case 4:
                 if (fourHours - 1 >= 0) {
                     fourHours--;

--- a/src/main/java/fr/lunatech/timekeeper/models/time/TimeEntry.java
+++ b/src/main/java/fr/lunatech/timekeeper/models/time/TimeEntry.java
@@ -20,6 +20,7 @@ import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -37,9 +38,9 @@ public class TimeEntry extends PanacheEntityBase {
     public TimeSheet timeSheet;
 
     @NotNull
-    public LocalDateTime startDateTime;
+    public LocalDate startDate;
 
     @NotNull
-    public LocalDateTime endDateTime;
+    public Integer numberOfHours;
 
 }

--- a/src/main/java/fr/lunatech/timekeeper/services/TimeEntryService.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/TimeEntryService.java
@@ -20,7 +20,6 @@ import fr.lunatech.timekeeper.gauges.TimeEntriesNumberPerHoursGauge;
 import fr.lunatech.timekeeper.models.time.TimeEntry;
 import fr.lunatech.timekeeper.resources.exceptions.CreateResourceException;
 import fr.lunatech.timekeeper.services.requests.TimeEntryRequest;
-import fr.lunatech.timekeeper.timeutils.TimeKeeperDateUtils;
 import io.quarkus.security.ForbiddenException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +61,7 @@ public class TimeEntryService {
         logger.debug("Modify timeEntry for id={} with {}, {}", timeSheetId, request, ctx);
         Optional<TimeEntry> timeEntryOptional = findById(timeEntryId, ctx);
         timeEntryOptional.ifPresent(timeEntry -> {
-            int oldNumberOfHours = TimeKeeperDateUtils.numberOfHoursBetween(timeEntry.startDateTime, timeEntry.endDateTime).intValue();
+            int oldNumberOfHours = timeEntry.numberOfHours;
             if (oldNumberOfHours != request.getNumberHours()) {
                 timeEntriesNumberPerHoursGauge.decrementGauges(oldNumberOfHours);
                 timeEntriesNumberPerHoursGauge.incrementGauges(request.getNumberHours());
@@ -74,7 +73,7 @@ public class TimeEntryService {
     }
 
     Optional<TimeEntry> findById(Long id, AuthenticationContext ctx) {
-        return TimeEntry.<TimeEntry>findByIdOptional(id)
+        return TimeEntry.<TimeEntry>findByIdOptional(id) //NOSONAR
                 .filter(ctx::canAccess);
     }
 }

--- a/src/main/java/fr/lunatech/timekeeper/services/TimeEntryService.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/TimeEntryService.java
@@ -49,7 +49,7 @@ public class TimeEntryService {
         }
         try {
             timeEntry.persistAndFlush();
-            timeEntriesNumberPerHoursGauge.incrementGauges(request.getNumberHours());
+            timeEntriesNumberPerHoursGauge.incrementGauges(request.getnumberOfHours());
         } catch (PersistenceException pe) {
             throw new CreateResourceException("TimeEntry was not created due to constraint violation");
         }
@@ -62,9 +62,9 @@ public class TimeEntryService {
         Optional<TimeEntry> timeEntryOptional = findById(timeEntryId, ctx);
         timeEntryOptional.ifPresent(timeEntry -> {
             int oldNumberOfHours = timeEntry.numberOfHours;
-            if (oldNumberOfHours != request.getNumberHours()) {
+            if (oldNumberOfHours != request.getnumberOfHours()) {
                 timeEntriesNumberPerHoursGauge.decrementGauges(oldNumberOfHours);
-                timeEntriesNumberPerHoursGauge.incrementGauges(request.getNumberHours());
+                timeEntriesNumberPerHoursGauge.incrementGauges(request.getnumberOfHours());
             }
         });
         return timeEntryOptional

--- a/src/main/java/fr/lunatech/timekeeper/services/requests/TimeEntryRequest.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/requests/TimeEntryRequest.java
@@ -24,7 +24,7 @@ import fr.lunatech.timekeeper.services.exceptions.IllegalEntityStateException;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
@@ -35,19 +35,19 @@ public class TimeEntryRequest {
     private final String comment;
 
     @NotNull
-    private final LocalDateTime startDateTime;
+    private final LocalDate startDate;
 
     @NotNull
     private final Integer numberHours;
 
     public TimeEntryRequest(
             @NotBlank String comment,
-            @NotNull LocalDateTime startDateTime,
-            @NotNull Integer numberHours
+            @NotNull LocalDate startDate,
+            @NotNull Integer hours
     ) {
         this.comment = comment;
-        this.startDateTime = startDateTime;
-        this.numberHours = numberHours;
+        this.startDate = startDate;
+        this.numberHours = hours;
     }
 
     public TimeEntry unbind(
@@ -66,8 +66,8 @@ public class TimeEntryRequest {
             @NotNull AuthenticationContext ctx
     ) {
         timeEntry.comment = getComment();
-        timeEntry.startDateTime = getStartDateTime();
-        timeEntry.endDateTime = getStartDateTime().plusHours(getNumberHours());
+        timeEntry.startDate = getStartDate();
+        timeEntry.numberOfHours = getNumberHours();
         timeEntry.timeSheet = findTimeSheet.apply(timeSheetId, ctx).orElseThrow(() -> new IllegalEntityStateException("TimeSheet not found for id " + timeSheetId));
         return timeEntry;
     }
@@ -76,8 +76,8 @@ public class TimeEntryRequest {
         return comment;
     }
 
-    public LocalDateTime getStartDateTime() {
-        return startDateTime;
+    public @NotNull LocalDate getStartDate() {
+        return startDate;
     }
 
     public Integer getNumberHours() {
@@ -88,8 +88,8 @@ public class TimeEntryRequest {
     public String toString() {
         return "TimeEntryRequest{" +
                 "comment='" + comment + '\'' +
-                ", startDateTime=" + startDateTime +
-                ", numberHours=" + numberHours +
+                ", startDate=" + startDate +
+                ", numberHours=" + getNumberHours() +
                 '}';
     }
 }

--- a/src/main/java/fr/lunatech/timekeeper/services/requests/TimeEntryRequest.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/requests/TimeEntryRequest.java
@@ -38,7 +38,7 @@ public class TimeEntryRequest {
     private final LocalDate startDate;
 
     @NotNull
-    private final Integer numberHours;
+    private final Integer numberOfHours;
 
     public TimeEntryRequest(
             @NotBlank String comment,
@@ -47,7 +47,7 @@ public class TimeEntryRequest {
     ) {
         this.comment = comment;
         this.startDate = startDate;
-        this.numberHours = hours;
+        this.numberOfHours = hours;
     }
 
     public TimeEntry unbind(
@@ -67,7 +67,7 @@ public class TimeEntryRequest {
     ) {
         timeEntry.comment = getComment();
         timeEntry.startDate = getStartDate();
-        timeEntry.numberOfHours = getNumberHours();
+        timeEntry.numberOfHours = getnumberOfHours();
         timeEntry.timeSheet = findTimeSheet.apply(timeSheetId, ctx).orElseThrow(() -> new IllegalEntityStateException("TimeSheet not found for id " + timeSheetId));
         return timeEntry;
     }
@@ -80,8 +80,8 @@ public class TimeEntryRequest {
         return startDate;
     }
 
-    public Integer getNumberHours() {
-        return numberHours;
+    public Integer getnumberOfHours() {
+        return numberOfHours;
     }
 
     @Override
@@ -89,7 +89,7 @@ public class TimeEntryRequest {
         return "TimeEntryRequest{" +
                 "comment='" + comment + '\'' +
                 ", startDate=" + startDate +
-                ", numberHours=" + getNumberHours() +
+                ", numberOfHours=" + getnumberOfHours() +
                 '}';
     }
 }

--- a/src/main/java/fr/lunatech/timekeeper/services/responses/TimeSheetResponse.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/responses/TimeSheetResponse.java
@@ -106,7 +106,7 @@ public class TimeSheetResponse {
 
         @NotNull
         @JsonFormat(pattern = TimeKeeperDateFormat.DEFAULT_DATE_PATTERN)
-        public final LocalDate day;
+        public final LocalDate startDate;
 
         @NotNull
         public final Integer numberOfHours;
@@ -114,12 +114,12 @@ public class TimeSheetResponse {
         public TimeEntryResponse(
                 @NotNull Long id,
                 @NotNull String comment,
-                @NotNull LocalDate day,
+                @NotNull LocalDate startDate,
                 @NotNull Integer numberOfHours
         ) {
             this.id = id;
             this.comment = comment;
-            this.day = day;
+            this.startDate = startDate;
             this.numberOfHours = numberOfHours;
         }
 
@@ -143,7 +143,7 @@ public class TimeSheetResponse {
         List<TimeEntryResponse> restrictedEntries = this.entries
                 .stream()
                 .filter(timeEntryResponse -> {
-                    return isValidDate.test(timeEntryResponse.day);
+                    return isValidDate.test(timeEntryResponse.startDate);
                 })
                 .collect(Collectors.toList());
 
@@ -164,7 +164,7 @@ public class TimeSheetResponse {
     public final TimeSheetResponse filterTimeEntriesForWeek(LocalDate startDayOfWeek){
         List<TimeEntryResponse> restrictedEntries = this.entries
                 .stream()
-                .filter(timeEntryResponse -> TimeKeeperDateUtils.isSameWeekAndYear(timeEntryResponse.day, startDayOfWeek))
+                .filter(timeEntryResponse -> TimeKeeperDateUtils.isSameWeekAndYear(timeEntryResponse.startDate, startDayOfWeek))
                 .collect(Collectors.toList());
 
         return new TimeSheetResponse(this.id,

--- a/src/main/java/fr/lunatech/timekeeper/services/responses/TimeSheetResponse.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/responses/TimeSheetResponse.java
@@ -26,7 +26,6 @@ import fr.lunatech.timekeeper.timeutils.TimeUnit;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -106,31 +105,30 @@ public class TimeSheetResponse {
         public final String comment;
 
         @NotNull
-        @JsonFormat(pattern = TimeKeeperDateFormat.DEFAULT_DATE_TIME_PATTERN)
-        public final LocalDateTime startDateTime;
+        @JsonFormat(pattern = TimeKeeperDateFormat.DEFAULT_DATE_PATTERN)
+        public final LocalDate day;
 
         @NotNull
-        @JsonFormat(pattern = TimeKeeperDateFormat.DEFAULT_DATE_TIME_PATTERN)
-        public final LocalDateTime endDateTime;
+        public final Integer numberOfHours;
 
         public TimeEntryResponse(
                 @NotNull Long id,
                 @NotNull String comment,
-                @NotNull LocalDateTime startDateTime,
-                @NotNull LocalDateTime endDateTime
+                @NotNull LocalDate day,
+                @NotNull Integer numberOfHours
         ) {
             this.id = id;
             this.comment = comment;
-            this.startDateTime = startDateTime;
-            this.endDateTime = endDateTime;
+            this.day = day;
+            this.numberOfHours = numberOfHours;
         }
 
         public static TimeSheetResponse.TimeEntryResponse bind(@NotNull TimeEntry timeEntry) {
             return new TimeSheetResponse.TimeEntryResponse(
                     timeEntry.id,
                     timeEntry.comment,
-                    timeEntry.startDateTime,
-                    timeEntry.endDateTime
+                    timeEntry.startDate,
+                    timeEntry.numberOfHours
             );
         }
 
@@ -145,8 +143,7 @@ public class TimeSheetResponse {
         List<TimeEntryResponse> restrictedEntries = this.entries
                 .stream()
                 .filter(timeEntryResponse -> {
-                    LocalDateTime startDateTime = timeEntryResponse.startDateTime;
-                    return isValidDate.test(startDateTime.toLocalDate());
+                    return isValidDate.test(timeEntryResponse.day);
                 })
                 .collect(Collectors.toList());
 
@@ -167,7 +164,7 @@ public class TimeSheetResponse {
     public final TimeSheetResponse filterTimeEntriesForWeek(LocalDate startDayOfWeek){
         List<TimeEntryResponse> restrictedEntries = this.entries
                 .stream()
-                .filter(timeEntryResponse -> TimeKeeperDateUtils.isSameWeekAndYear(timeEntryResponse.startDateTime.toLocalDate(), startDayOfWeek))
+                .filter(timeEntryResponse -> TimeKeeperDateUtils.isSameWeekAndYear(timeEntryResponse.day, startDayOfWeek))
                 .collect(Collectors.toList());
 
         return new TimeSheetResponse(this.id,

--- a/src/main/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtils.java
+++ b/src/main/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtils.java
@@ -143,14 +143,4 @@ public class TimeKeeperDateUtils {
         return inputDate -> inputDate.isAfter(firstDayOfFirstWeek.minusDays(1)) && inputDate.isBefore(lastDayOfLastWeek.plusDays(1));
     }
 
-    /**
-     * Compute the number of hours between two LocalDateTime
-     * @param start
-     * @param end
-     * @return the number of hours between start and end
-     */
-    public static Long numberOfHoursBetween(LocalDateTime start, LocalDateTime end) {
-        if(start.isAfter(end)) throw new IllegalStateException("The start date is after end date ");
-        return Duration.between(start, end).toHours();
-    }
 }

--- a/src/main/java/fr/lunatech/timekeeper/timeutils/TimeSheetUtils.java
+++ b/src/main/java/fr/lunatech/timekeeper/timeutils/TimeSheetUtils.java
@@ -18,23 +18,25 @@ package fr.lunatech.timekeeper.timeutils;
 
 import fr.lunatech.timekeeper.models.time.TimeSheet;
 
-import java.time.Duration;
-
 public class TimeSheetUtils {
 
     private static final int NUMBER_OF_HOURS_IN_A_DAY = 8;
     private static final int NUMBER_OF_HOURS_IN_HALF_A_DAY = 4;
 
+    private TimeSheetUtils() {
+
+    }
+
     public static Long computeLeftOver(TimeSheet sheet) {
         if (null != sheet.maxDuration && sheet.maxDuration > 0) {
             // Early exit if no entry : left = maxDuration
-            if(sheet.entries == null || sheet.entries.isEmpty()){
+            if (sheet.entries == null || sheet.entries.isEmpty()) {
                 return sheet.maxDuration.longValue();
             }
 
             long consumedHours = sheet.entries.stream()
-                            .mapToLong(timeEntry -> Duration.between(timeEntry.startDateTime, timeEntry.endDateTime).toHours())
-                            .sum();
+                    .mapToLong(timeEntry -> timeEntry.numberOfHours)
+                    .sum();
 
             // Compute what's left based on durationUnit type (see constant)
             if (sheet.durationUnit != null) {
@@ -45,6 +47,8 @@ public class TimeSheetUtils {
                         return ((sheet.maxDuration * NUMBER_OF_HOURS_IN_HALF_A_DAY) - consumedHours) / NUMBER_OF_HOURS_IN_A_DAY;
                     case HOURLY:
                         return (sheet.maxDuration - consumedHours) / NUMBER_OF_HOURS_IN_A_DAY;
+                    default:
+                        throw new IllegalStateException("Invalid duration unit for sheet=" + sheet);
                 }
             } else {
                 // if no durationUnit let's consider it's a day based duration

--- a/src/main/resources/db/migration/V16__alter_timeentry_for_date_duration.sql
+++ b/src/main/resources/db/migration/V16__alter_timeentry_for_date_duration.sql
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Lunatech S.A.S
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE timeentries ADD COLUMN startdate date;
+ALTER TABLE timeentries ADD COLUMN numberOfHours int4 DEFAULT 0;
+
+/*
+Please note that H2 does not support the follow SQL statement since DATE() function does not exist with H2
+
+UPDATE timeentries as T1
+SET startdate = (SELECT DATE(startdatetime)::TIMESTAMP::DATE FROM public.timeentries AS T2 WHERE T2.id = T1.id),
+numberOfHours = (select EXTRACT(EPOCH FROM (enddatetime - startdatetime ))/3600  as diff_time_hours from timeentries T3 WHERE T3.id = T1.id);
+
+-- We can then drop columns once the data are migrated
+ALTER TABLE timeentries DROP COLUMN startdatetime;
+ALTER TABLE timeentries DROP COLUMN enddatetime;
+
+ */

--- a/src/test/java/fr/lunatech/timekeeper/resources/PersonalTimesheetsResourceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/resources/PersonalTimesheetsResourceTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -157,18 +156,18 @@ class PersonalTimesheetsResourceTest {
         );
 
 
-        LocalDateTime firstDateTime = LocalDateTime.of(2020, 7, 29, 9, 0);
+        LocalDate firstDateTime = LocalDate.of(2020, 7, 29);
         TimeEntryRequest entryOnFirstDateExpected = new TimeEntryRequest("Today, I did this test", firstDateTime, 8);
-        LocalDateTime lastDateTime = LocalDateTime.of(2020, 7, 31, 9, 0);
+        LocalDate lastDateTime = LocalDate.of(2020, 7, 31);
         TimeEntryRequest entryOnLastDateExpected = new TimeEntryRequest("Today, I did this test", lastDateTime, 8);
-        LocalDateTime includedDayDateTime = LocalDateTime.of(2020, 7, 5, 9, 0);
+        LocalDate includedDayDateTime = LocalDate.of(2020, 7, 5);
         TimeEntryRequest includedDay = new TimeEntryRequest("Today, I did this test", includedDayDateTime, 8);
-        LocalDateTime notIncludedDayDateTime = LocalDateTime.of(2020, 6, 28, 9, 0);
+        LocalDate notIncludedDayDateTime = LocalDate.of(2020, 6, 28);
         TimeEntryRequest notIncludedDay = new TimeEntryRequest("Today, I did this test", notIncludedDayDateTime, 8);
 
-        TimeSheetResponse.TimeEntryResponse entryResponseOnFirstDateExpected = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I did this test", firstDateTime, firstDateTime.plusHours(8));
-        TimeSheetResponse.TimeEntryResponse entryResponseOnLastDateExpected = new TimeSheetResponse.TimeEntryResponse(2L, "Today, I did this test", lastDateTime, lastDateTime.plusHours(8));
-        TimeSheetResponse.TimeEntryResponse includedDayResponse = new TimeSheetResponse.TimeEntryResponse(3L, "Today, I did this test", includedDayDateTime, includedDayDateTime.plusHours(8));
+        TimeSheetResponse.TimeEntryResponse entryResponseOnFirstDateExpected = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I did this test", firstDateTime, 8);
+        TimeSheetResponse.TimeEntryResponse entryResponseOnLastDateExpected = new TimeSheetResponse.TimeEntryResponse(2L, "Today, I did this test", lastDateTime, 8);
+        TimeSheetResponse.TimeEntryResponse includedDayResponse = new TimeSheetResponse.TimeEntryResponse(3L, "Today, I did this test", includedDayDateTime, 8);
         var timeEntriesExpected = List.of(entryResponseOnFirstDateExpected,
                 entryResponseOnLastDateExpected,
                 includedDayResponse);
@@ -267,18 +266,17 @@ class PersonalTimesheetsResourceTest {
                 START_DATE
         );
         String commentDay = "I worked on Disney content API for 8h";
-        LocalDateTime startDay1 = LocalDateTime.of(2020, 6, 18, 10, 0);
-        LocalDateTime endDay1 = LocalDateTime.of(2020, 6, 18, 18, 0);
-        LocalDateTime startDay2 = LocalDateTime.of(2020, 6, 19, 8, 0);
-        LocalDateTime endDay2 = LocalDateTime.of(2020, 6, 19, 16, 0);
+        LocalDate startDay1 = LocalDate.of(2020, 6, 18);
+        LocalDate startDay2 = LocalDate.of(2020, 6, 19);
+
         TimeEntryRequest jimmyEntry1 = new TimeEntryRequest(commentDay, startDay1, 8);
         TimeEntryRequest jimmyEntry2 = new TimeEntryRequest(commentDay, startDay2, 8);
         update(updatedTimeSheet, TimeSheetDef.uriPlusId(1L), jimmyToken);
         create(1L, jimmyEntry1, jimmyToken);
         create(1L, jimmyEntry2, jimmyToken);
 
-        TimeSheetResponse.TimeEntryResponse jimmyEntryDay1Response = new TimeSheetResponse.TimeEntryResponse(1L, commentDay, startDay1, endDay1);
-        TimeSheetResponse.TimeEntryResponse jimmyEntryDay2Response = new TimeSheetResponse.TimeEntryResponse(2L, commentDay, startDay2, endDay2);
+        TimeSheetResponse.TimeEntryResponse jimmyEntryDay1Response = new TimeSheetResponse.TimeEntryResponse(1L, commentDay, startDay1, 8);
+        TimeSheetResponse.TimeEntryResponse jimmyEntryDay2Response = new TimeSheetResponse.TimeEntryResponse(2L, commentDay, startDay2, 8);
 
         final var timesheet = new TimeSheetResponse(1L, projectResponse, jimmy.getId(), TimeUnit.HOURLY, true, null, 10, TimeUnit.DAY.toString(), List.of(jimmyEntryDay1Response, jimmyEntryDay2Response), 8L, START_DATE);
         WeekResponse response = new WeekResponse(LocalDate.of(2020, 6, 15), Collections.emptyList(), List.of(timesheet), new ArrayList<>());

--- a/src/test/java/fr/lunatech/timekeeper/resources/TimeEntryResourceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/resources/TimeEntryResourceTest.java
@@ -88,13 +88,13 @@ class TimeEntryResourceTest {
         final var expectedTimeSheetJimmy = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(), Collections.emptyList(), null, START_DATE);
 
         getValidation(TimeSheetPerProjectPerUserDef.uriWithMultiId(project.getId(), jimmy.getId()), adminToken).body(is(timeKeeperTestUtils.toJson(expectedTimeSheetJimmy))).statusCode(is(OK.getStatusCode()));
-        LocalDateTime startDateTime = LocalDateTime.of(2020, 1, 1, 9, 0);
-        TimeEntryRequest today = new TimeEntryRequest("Today, I did this test", startDateTime, 8);
+        LocalDate startDate = LocalDate.of(2020, 1, 1);
+        TimeEntryRequest today = new TimeEntryRequest("Today, I did this test", startDate, 8);
 
         create(2L, today, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I did this test", startDateTime, startDateTime.withHour(17).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I did this test", startDate, 8);
 
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
@@ -120,13 +120,13 @@ class TimeEntryResourceTest {
         final var expectedTimeSheetJimmy = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(), Collections.emptyList(), null, START_DATE);
 
         getValidation(TimeSheetPerProjectPerUserDef.uriWithMultiId(project.getId(), jimmy.getId()), adminToken).body(is(timeKeeperTestUtils.toJson(expectedTimeSheetJimmy))).statusCode(is(OK.getStatusCode()));
-        LocalDateTime startDateTime = LocalDateTime.of(2020, 1, 1, 9, 0);
-        TimeEntryRequest morning = new TimeEntryRequest("This morning, I did this test", LocalDateTime.of(2020, 1, 1, 9, 0), 4);
+        LocalDate startDate = LocalDate.of(2020, 1, 1);
+        TimeEntryRequest morning = new TimeEntryRequest("This morning, I did this test", LocalDate.of(2020, 1, 1), 4);
 
         create(2L, morning, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This morning, I did this test", startDateTime, startDateTime.withHour(13).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This morning, I did this test", startDate, 4);
 
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
@@ -152,14 +152,13 @@ class TimeEntryResourceTest {
         final var expectedTimeSheetJimmy = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(), Collections.emptyList(), null, START_DATE);
 
         getValidation(TimeSheetPerProjectPerUserDef.uriWithMultiId(project.getId(), jimmy.getId()), adminToken).body(is(timeKeeperTestUtils.toJson(expectedTimeSheetJimmy))).statusCode(is(OK.getStatusCode()));
-        LocalDateTime start = LocalDateTime.of(2020, 1, 1, 10, 0);
-        LocalDateTime end = LocalDateTime.of(2020, 1, 1, 11, 0);
+        LocalDate start = LocalDate.of(2020, 1, 1);
         TimeEntryRequest hour = new TimeEntryRequest("This hour, I did this test", start, 1);
 
         create(2L, hour, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I did this test", start, end);
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I did this test", start, 1);
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
 
@@ -184,7 +183,7 @@ class TimeEntryResourceTest {
         final var expectedTimeSheetJimmy = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(), Collections.emptyList(), null, START_DATE);
 
         getValidation(TimeSheetPerProjectPerUserDef.uriWithMultiId(project.getId(), jimmy.getId()), adminToken).body(is(timeKeeperTestUtils.toJson(expectedTimeSheetJimmy))).statusCode(is(OK.getStatusCode()));
-        LocalDateTime start = LocalDateTime.of(2020, 1, 1, 11, 0);
+        LocalDate start = LocalDate.of(2020, 1, 1);
 
         TimeEntryRequest hour = new TimeEntryRequest("This hour, I did this test", start, -1);
 
@@ -215,8 +214,8 @@ class TimeEntryResourceTest {
         final var expectedTimeSheetJimmy = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(), Collections.emptyList(), null, START_DATE);
 
         getValidation(TimeSheetPerProjectPerUserDef.uriWithMultiId(project.getId(), jimmy.getId()), adminToken).body(is(timeKeeperTestUtils.toJson(expectedTimeSheetJimmy))).statusCode(is(OK.getStatusCode()));
-        LocalDateTime startDateTime = LocalDateTime.of(2020, 1, 1, 9, 0);
-        TimeEntryRequest today = new TimeEntryRequest("Today, I did this test", startDateTime, 8);
+        LocalDate startDate = LocalDate.of(2020, 1, 1);
+        TimeEntryRequest today = new TimeEntryRequest("Today, I did this test", startDate, 8);
 
         // THEN
         postValidation(TimeEntryDef.uriWithArgs(2L), merryToken, today).statusCode(is(FORBIDDEN.getStatusCode()));
@@ -239,16 +238,16 @@ class TimeEntryResourceTest {
         final var expectedTimeSheetJimmy = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(), Collections.emptyList(), null, START_DATE);
 
         getValidation(TimeSheetPerProjectPerUserDef.uriWithMultiId(project.getId(), jimmy.getId()), adminToken).body(is(timeKeeperTestUtils.toJson(expectedTimeSheetJimmy))).statusCode(is(OK.getStatusCode()));
-        LocalDateTime startDateTime = LocalDateTime.of(2020, 1, 1, 9, 0);
-        TimeEntryRequest today = new TimeEntryRequest("Today, I did this test", startDateTime, 8);
+        LocalDate startDate = LocalDate.of(2020, 1, 1);
+        TimeEntryRequest today = new TimeEntryRequest("Today, I did this test", startDate, 8);
 
         var location = create(2L, today, jimmyToken);
 
-        TimeEntryRequest updatedToday = new TimeEntryRequest("Today, I updated this entry", startDateTime, 8);
+        TimeEntryRequest updatedToday = new TimeEntryRequest("Today, I updated this entry", startDate, 8);
         update(updatedToday, location, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I updated this entry", startDateTime, startDateTime.withHour(17).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I updated this entry", startDate, 8);
 
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
@@ -274,16 +273,16 @@ class TimeEntryResourceTest {
         final var expectedTimeSheetJimmy = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(), Collections.emptyList(), null, START_DATE);
 
         getValidation(TimeSheetPerProjectPerUserDef.uriWithMultiId(project.getId(), jimmy.getId()), adminToken).body(is(timeKeeperTestUtils.toJson(expectedTimeSheetJimmy))).statusCode(is(OK.getStatusCode()));
-        LocalDateTime startDateTime = LocalDateTime.of(2020, 1, 1, 9, 0);
-        TimeEntryRequest morning = new TimeEntryRequest("This morning, I did this test", LocalDateTime.of(2020, 1, 1, 9, 0), 4);
+        LocalDate startDate= LocalDate.of(2020, 1, 1);
+        TimeEntryRequest morning = new TimeEntryRequest("This morning, I did this test", LocalDate.of(2020, 1, 1), 4);
 
         var location = create(2L, morning, jimmyToken);
 
-        TimeEntryRequest updatedMorning = new TimeEntryRequest("This morning, I updated this entry", startDateTime, 4);
+        TimeEntryRequest updatedMorning = new TimeEntryRequest("This morning, I updated this entry", startDate, 4);
         update(updatedMorning, location, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This morning, I updated this entry", startDateTime, startDateTime.withHour(13).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This morning, I updated this entry", startDate, 4);
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
 
@@ -308,16 +307,16 @@ class TimeEntryResourceTest {
         final var expectedTimeSheetJimmy = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(), Collections.emptyList(), null, START_DATE);
 
         getValidation(TimeSheetPerProjectPerUserDef.uriWithMultiId(project.getId(), jimmy.getId()), adminToken).body(is(timeKeeperTestUtils.toJson(expectedTimeSheetJimmy))).statusCode(is(OK.getStatusCode()));
-        LocalDateTime startDateTime = LocalDateTime.of(2020, 1, 1, 9, 0);
-        TimeEntryRequest hour = new TimeEntryRequest("This hour, I did this test", LocalDateTime.of(2020, 1, 1, 9, 0), 1);
+        LocalDate startDate = LocalDate.of(2020, 1, 1);
+        TimeEntryRequest hour = new TimeEntryRequest("This hour, I did this test", LocalDate.of(2020, 1, 1), 1);
 
         var location = create(2L, hour, jimmyToken);
 
-        TimeEntryRequest updatedHour = new TimeEntryRequest("This hour, I updated this entry", startDateTime, 1);
+        TimeEntryRequest updatedHour = new TimeEntryRequest("This hour, I updated this entry", startDate, 1);
         update(updatedHour, location, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I updated this entry", startDateTime, startDateTime.withHour(10).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I updated this entry", startDate, 1);
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
         var expected = timeKeeperTestUtils.toJson(expectedTimeSheetJimmy2);
@@ -341,16 +340,16 @@ class TimeEntryResourceTest {
         final var expectedTimeSheetJimmy = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(), Collections.emptyList(), null, START_DATE);
 
         getValidation(TimeSheetPerProjectPerUserDef.uriWithMultiId(project.getId(), jimmy.getId()), adminToken).body(is(timeKeeperTestUtils.toJson(expectedTimeSheetJimmy))).statusCode(is(OK.getStatusCode()));
-        LocalDateTime startDateTime = LocalDateTime.of(2020, 1, 1, 9, 0);
-        TimeEntryRequest hour = new TimeEntryRequest("This hour, I did this test", LocalDateTime.of(2020, 1, 1, 9, 0), 1);
+        LocalDate startDate= LocalDate.of(2020, 1, 1);
+        TimeEntryRequest hour = new TimeEntryRequest("This hour, I did this test", LocalDate.of(2020, 1, 1),1);
 
         var location = create(2L, hour, jimmyToken);
 
-        TimeEntryRequest updatedHour = new TimeEntryRequest("This hour, I did this test", startDateTime, 2);
+        TimeEntryRequest updatedHour = new TimeEntryRequest("This hour, I did this test but in 2 hours", startDate, 2);
         update(updatedHour, location, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I did this test", startDateTime, startDateTime.withHour(11).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I did this test but in 2 hours", startDate, 2);
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
 

--- a/src/test/java/fr/lunatech/timekeeper/services/AuthenticationContextTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/AuthenticationContextTest.java
@@ -23,6 +23,7 @@ import fr.lunatech.timekeeper.models.time.TimeSheet;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -231,8 +232,8 @@ class AuthenticationContextTest {
 
         TimeEntry timeEntry = new TimeEntry();
         timeEntry.id=999L;
-        timeEntry.startDateTime= LocalDateTime.now();
-        timeEntry.endDateTime= LocalDateTime.now();
+        timeEntry.startDate= LocalDate.now();
+        timeEntry.numberOfHours=8;
         timeEntry.timeSheet = timeSheet;
         timeEntry.comment = "??";
 
@@ -708,8 +709,8 @@ class AuthenticationContextTest {
 
         TimeEntry timeEntry = new TimeEntry();
         timeEntry.id=999L;
-        timeEntry.startDateTime= LocalDateTime.now();
-        timeEntry.endDateTime= LocalDateTime.now();
+        timeEntry.startDate= LocalDate.now();
+        timeEntry.numberOfHours = 8;
         timeEntry.timeSheet = timeSheet;
         timeEntry.comment = "??";
 
@@ -753,8 +754,8 @@ class AuthenticationContextTest {
 
         TimeEntry timeEntry = new TimeEntry();
         timeEntry.id=999L;
-        timeEntry.startDateTime= LocalDateTime.now();
-        timeEntry.endDateTime= LocalDateTime.now();
+        timeEntry.startDate= LocalDate.now();
+        timeEntry.numberOfHours = 8;
         timeEntry.timeSheet = timeSheet;
         timeEntry.comment = "??";
 
@@ -797,8 +798,8 @@ class AuthenticationContextTest {
 
         TimeEntry timeEntry = new TimeEntry();
         timeEntry.id=999L;
-        timeEntry.startDateTime= LocalDateTime.now();
-        timeEntry.endDateTime= LocalDateTime.now();
+        timeEntry.startDate= LocalDate.now();
+        timeEntry.numberOfHours = 8;
         timeEntry.timeSheet = timeSheet;
         timeEntry.comment = "??";
 
@@ -841,8 +842,8 @@ class AuthenticationContextTest {
 
         TimeEntry timeEntry = new TimeEntry();
         timeEntry.id=999L;
-        timeEntry.startDateTime= LocalDateTime.now();
-        timeEntry.endDateTime= LocalDateTime.now();
+        timeEntry.startDate= LocalDate.now();
+        timeEntry.numberOfHours = 8;
         timeEntry.timeSheet = timeSheet;
         timeEntry.comment = "??";
 

--- a/src/test/java/fr/lunatech/timekeeper/services/responses/TimeSheetResponseTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/responses/TimeSheetResponseTest.java
@@ -54,18 +54,18 @@ class TimeSheetResponseTest {
     void should_drop_entries_not_in_6_weeks_timerange(){
         TimeSheetResponse.TimeEntryResponse july14 = new TimeSheetResponse.TimeEntryResponse(1L,
                 "comment",
-                LocalDateTime.of(2020,7,14,9,00),
-                LocalDateTime.of(2020,7,14,17,00)
+                LocalDate.of(2020,7,14),
+                8
         );
         TimeSheetResponse.TimeEntryResponse august15 = new TimeSheetResponse.TimeEntryResponse(2L,
                 "comment",
-                LocalDateTime.of(2020,8,15,9,00),
-                LocalDateTime.of(2020,8,15,17,00)
+                LocalDate.of(2020,8,15),
+                8
         );
         TimeSheetResponse.TimeEntryResponse junePreviousYear = new TimeSheetResponse.TimeEntryResponse(3L,
                 "comment",
-                LocalDateTime.of(2019,6,14,9,00),
-                LocalDateTime.of(2019,6,14,13,00)
+                LocalDate.of(2019,6,14),
+                4
         );
 
         List<TimeSheetResponse.TimeEntryResponse> initialDates = List.of(july14,junePreviousYear,august15);
@@ -94,29 +94,24 @@ class TimeSheetResponseTest {
     @Test
     void should_keepdates_in_6_weeks_timerange(){
         TimeSheetResponse.TimeEntryResponse december29 = new TimeSheetResponse.TimeEntryResponse(1L,
-                "comment",
-                LocalDateTime.of(2019,12,29,9,00),
-                LocalDateTime.of(2019,12,29,17,00)
+                "comment 5",
+                LocalDate.of(2019,12,29),8
         );
         TimeSheetResponse.TimeEntryResponse december30 = new TimeSheetResponse.TimeEntryResponse(2L,
-                "comment",
-                LocalDateTime.of(2019,12,30,9,00),
-                LocalDateTime.of(2019,12,30,17,00)
+                "comment 4",
+                LocalDate.of(2019,12,30),8
         );
         TimeSheetResponse.TimeEntryResponse january20 = new TimeSheetResponse.TimeEntryResponse(3L,
-                "comment",
-                LocalDateTime.of(2020,1,20,9,00),
-                LocalDateTime.of(2020,1,20,17,00)
+                "comment 3",
+                LocalDate.of(2020,1,20),8
         );
         TimeSheetResponse.TimeEntryResponse february9 = new TimeSheetResponse.TimeEntryResponse(4L,
-                "comment",
-                LocalDateTime.of(2020,2,9,9,00),
-                LocalDateTime.of(2020,2,9,13,00)
+                "comment 1",
+                LocalDate.of(2020,2,9),4
         );
         TimeSheetResponse.TimeEntryResponse february10 = new TimeSheetResponse.TimeEntryResponse(5L,
-                "comment",
-                LocalDateTime.of(2020,2,10,9,00),
-                LocalDateTime.of(2020,2,10,13,00)
+                "comment 2",
+                LocalDate.of(2020,2,10),4
         );
 
         List<TimeSheetResponse.TimeEntryResponse> initialDates = List.of(december29,december30,january20,february9,february10);

--- a/src/test/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtilsTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtilsTest.java
@@ -330,24 +330,4 @@ class TimeKeeperDateUtilsTest {
         assertEquals(expected, TimeKeeperDateUtils.adjustToFirstDayOfWeek(inputDate));
     }
 
-    @Test
-    void shouldReturnNumberOfHours() {
-        LocalDateTime start = LocalDateTime.of(2020, 7, 2, 9, 0, 0);
-        LocalDateTime end = LocalDateTime.of(2020, 7, 2, 13, 0, 0);
-        assertEquals(4, TimeKeeperDateUtils.numberOfHoursBetween(start, end));
-    }
-
-    @Test
-    void shouldReturnNumberOfHoursForTwoDifferentDates() {
-        LocalDateTime start = LocalDateTime.of(2020, 7, 1, 23, 0, 0);
-        LocalDateTime end = LocalDateTime.of(2020, 7, 2, 1, 0, 0);
-        assertEquals(2, TimeKeeperDateUtils.numberOfHoursBetween(start, end));
-    }
-
-    @Test
-    void shouldThrowsExceptionWhenStartIsAfterEnd() {
-        LocalDateTime start = LocalDateTime.of(2020, 7, 2, 10, 0, 0);
-        LocalDateTime end = LocalDateTime.of(2020, 7, 2, 9, 0, 0);
-        assertThrows(IllegalStateException.class, () -> TimeKeeperDateUtils.numberOfHoursBetween(start, end));
-    }
 }

--- a/src/test/java/fr/lunatech/timekeeper/timeutils/TimeSheetUtilsTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/timeutils/TimeSheetUtilsTest.java
@@ -18,11 +18,9 @@ package fr.lunatech.timekeeper.timeutils;
 
 import fr.lunatech.timekeeper.models.time.TimeEntry;
 import fr.lunatech.timekeeper.models.time.TimeSheet;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -48,12 +46,12 @@ class TimeSheetUtilsTest {
                 null,
                 10,
                 TimeUnit.DAY,
-                generateTestEntries(8,8L),
+                generateTestEntries(8, 8),
                 START_DATE
         );
 
         //THEN: only 2 hours left
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(2L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(2L));
     }
 
     @Test
@@ -74,7 +72,7 @@ class TimeSheetUtilsTest {
         );
 
         //THEN: 10 days left
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(10L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(10L));
     }
 
     @Test
@@ -90,12 +88,12 @@ class TimeSheetUtilsTest {
                 null,
                 4,
                 TimeUnit.HALFDAY,
-                generateTestEntries(1,8L),
+                generateTestEntries(1, 8),
                 START_DATE
         );
 
         //THEN: only 2 half day (1 day)
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(1L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(1L));
     }
 
     @Test
@@ -111,12 +109,12 @@ class TimeSheetUtilsTest {
                 null,
                 4,
                 TimeUnit.HALFDAY,
-                generateTestEntries(3,4L),
+                generateTestEntries(3, 4),
                 START_DATE
         );
 
         //THEN: only 1 half day left (rounded to 0 day)
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(0L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(0L));
     }
 
     @Test
@@ -132,12 +130,12 @@ class TimeSheetUtilsTest {
                 null,
                 20,
                 TimeUnit.HOURLY,
-                generateTestEntries(1,8L),
+                generateTestEntries(1, 8),
                 START_DATE
         );
 
         //THEN: only 12 hours left (1,5 day -> rounded 1 day)
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(1L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(1L));
     }
 
     @Test
@@ -153,12 +151,12 @@ class TimeSheetUtilsTest {
                 null,
                 8,
                 TimeUnit.HOURLY,
-                generateTestEntries(1,1L),
+                generateTestEntries(1, 1),
                 START_DATE
         );
 
         //THEN: only 7 hours left (rounded 0 day)
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(0L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(0L));
     }
 
     @Test
@@ -174,12 +172,12 @@ class TimeSheetUtilsTest {
                 null,
                 2,
                 TimeUnit.DAY,
-                generateTestEntries(4,8L),
+                generateTestEntries(4, 8),
                 START_DATE
         );
 
         //THEN: the result is negative
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(-2L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(-2L));
     }
 
     @Test
@@ -188,8 +186,8 @@ class TimeSheetUtilsTest {
 
         //WHEN the user entry is incorrect
         TimeEntry timeEntry = new TimeEntry();
-        timeEntry.startDateTime =LocalDateTime.now().minusHours(8L);
-        timeEntry.endDateTime = LocalDateTime.now();
+        timeEntry.startDate = LocalDate.now();
+        timeEntry.numberOfHours = 8;
         TimeSheet timesheet = new TimeSheet(
                 null,
                 null,
@@ -203,7 +201,7 @@ class TimeSheetUtilsTest {
         );
 
         //THEN: only 0 hours left (rounded 0 day)
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(0L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(0L));
     }
 
     @Test
@@ -219,12 +217,12 @@ class TimeSheetUtilsTest {
                 null,
                 null,
                 TimeUnit.HOURLY,
-                generateTestEntries(1,1L),
+                generateTestEntries(1, 1),
                 START_DATE
         );
 
         //THEN: no calculation are made
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(nullValue()));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(nullValue()));
     }
 
     @Test
@@ -240,12 +238,12 @@ class TimeSheetUtilsTest {
                 null,
                 -2,
                 TimeUnit.HOURLY,
-                generateTestEntries(1,1L),
+                generateTestEntries(1, 1),
                 START_DATE
         );
 
         //THEN: no calculation are made
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(nullValue()));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(nullValue()));
     }
 
     @Test
@@ -261,22 +259,22 @@ class TimeSheetUtilsTest {
                 null,
                 4,
                 null,
-                generateTestEntries(1,8L),
+                generateTestEntries(1, 8),
                 START_DATE
         );
 
         //THEN: limit is consider by day, therefor 3 is returned
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(3L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(3L));
     }
 
-    private List<TimeEntry> generateTestEntries (int numberOfEntry, long hourPerEntry){
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime nowPlusSomeHours = now.plusHours(hourPerEntry);
-        List<TimeEntry> entries = new ArrayList();
-        for (int i = 0 ; i<numberOfEntry;i++) {
+    private List<TimeEntry> generateTestEntries(int numberOfEntry, int duration) {
+        LocalDate now = LocalDate.now();
+        if (duration < 0) throw new IllegalStateException("Invalid duration");
+        List<TimeEntry> entries = new ArrayList<>();
+        for (int i = 0; i < numberOfEntry; i++) {
             TimeEntry entry = new TimeEntry();
-            entry.startDateTime = now;
-            entry.endDateTime = nowPlusSomeHours;
+            entry.startDate = now;
+            entry.numberOfHours = duration;
             entries.add(entry);
         }
         return entries;


### PR DESCRIPTION
TimeEntry on the backend was refactored so that we keep only a startDate and a duration. 
This new PR intends to remove the endDateTime and more globally, any start - end pattern in the JS code.

Almost everything was fixed. The only issue I could fix is when one edit a TimeEntry of 1 hour. There is a bug in `SelectHoursComponent` that I could not identify nor understand. Maybe @tkuy can check ? 
To reproduce this issue : create a public project and create a new timeEntry of 1 hour. Try to edit the TimeEntry => the page will not load.