### PR TITLE
Refacto on TimeEntry to use numberOfHours instead of endDateTime

### DIFF
--- a/frontend/src/components/TimeEntry/AddEntryForm.js
+++ b/frontend/src/components/TimeEntry/AddEntryForm.js
@@ -38,6 +38,7 @@ const initialValues = (defaultDate) => {
     'timeSheetId': null,
     'date': defaultDate,
     'startDateTime': start, //9 am by default
+    'numberOfHours':1
   };
 };
 
@@ -54,19 +55,19 @@ const additionalValues = (timeUnit, defaultDate, allValues) => {
     case 'DAY': {
       return {
         'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': 8
+        'numberOfHours': 8
       };
     }
     case 'HALFDAY': {
       return {
         'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': 4
+        'numberOfHours': 4
       };
     }
     case 'HOURLY' : {
       return {
         'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': null
+        'numberOfHours': allValues.numberOfHours
       };
     }
     default: {
@@ -131,6 +132,7 @@ const AddEntryForm = ({date, form, timeSheets, onSuccess, onCancel, numberOfHour
       >
         <TitleSection title='Add task'/>
         <Form.Item name="date" noStyle={true}>
+          <Input hidden={true}/>
         </Form.Item>
 
         <Form.Item label="Description:" name="comment" rules={[{required: true}]}>
@@ -167,6 +169,7 @@ const AddEntryForm = ({date, form, timeSheets, onSuccess, onCancel, numberOfHour
           </Col>
 
           <Form.Item name="startDateTime" noStyle={true}>
+            <Input hidden={true}/>
           </Form.Item>
 
           <Col className="gutter-row" span={9}>
@@ -182,7 +185,7 @@ const AddEntryForm = ({date, form, timeSheets, onSuccess, onCancel, numberOfHour
                     );
                   default:
                     return (
-                      <Form.Item name="numberHours" noStyle={true}>
+                      <Form.Item name="numberOfHours" noStyle={true}>
                         <Input hidden={true}/>
                       </Form.Item>
                     );
@@ -207,7 +210,7 @@ AddEntryForm.propTypes = {
   timeSheets: PropTypes.array.isRequired,
   onSuccess: PropTypes.func,
   onCancel: PropTypes.func,
-  numberOfHoursForDay: PropTypes.array
+  numberOfHoursForDay: PropTypes.number.isRequired
 };
 
 export default AddEntryForm;

--- a/frontend/src/components/TimeEntry/EditEntryForm.js
+++ b/frontend/src/components/TimeEntry/EditEntryForm.js
@@ -20,15 +20,14 @@ import {Button, Col, Form, Input, message, Radio, Row, Select, Space} from 'antd
 import PropTypes from 'prop-types';
 import TitleSection from '../Title/TitleSection';
 import moment from 'moment';
-import {computeNumberOfHours} from '../../utils/momentUtils';
 import SelectHoursComponent from './SelectHoursComponent';
 import {isTimeSheetDisabled} from '../../utils/timesheetUtils';
 
 const {Option} = Select;
 const {TextArea} = Input;
 
-const computeTimeUnit = (numberHours) => {
-  switch (numberHours) {
+const computeTimeUnit = (numberofHours) => {
+  switch (numberofHours) {
     case 4:
       return 'HALFDAY';
     case 8:
@@ -42,17 +41,16 @@ const initialValues = (defaultDate, entry, timeSheetId) => {
   const newEntry = {
     ...entry,
     startDateTime: moment.utc(entry.startDateTime),
-    endDateTime: moment.utc(entry.endDateTime)
+    numberOfHours: entry.numberOfHours
   };
-  const numberOfHours = computeNumberOfHours(newEntry.startDateTime, newEntry.endDateTime);
+  const numberOfHours = new Array(newEntry.numberOfHours);
   return {
     'comment': newEntry.comment,
     'timeSheetId': timeSheetId,
     'date': moment.utc(newEntry.startDateTime, 'YYYY-MM-DD'),
     'startDateTime': newEntry.startDateTime,
-    'endDateTime': newEntry.endDateTime,
     'timeUnit' : computeTimeUnit(numberOfHours),
-    'numberHours': numberOfHours
+    'numberOfHours': newEntry.numberOfHours
   };
 };
 
@@ -61,19 +59,19 @@ const updatedValues = (timeUnit, allValues, start) => {
     case 'DAY': {
       return {
         'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': 8
+        'numberOfHours': 8
       };
     }
     case 'HALFDAY': {
       return {
         'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': 4
+        'numberOfHours': 4
       };
     }
     case 'HOURLY' : {
       return {
         'startDateTime': allValues.startDateTime || start, //9 am by default
-        'numberHours': null
+        'numberOfHours': null
       };
     }
     default: {
@@ -104,7 +102,7 @@ const EditEntryForm = ({date, form, timeSheets, onSuccess, onCancel, entry, numb
   const [entryUpdated, setEntryUpdated] = useState(false);
   const [selectedTimeSheet, setSelectedTimeSheet] = useState();
   const timeKeeperAPIPut = useTimeKeeperAPIPut(urlEdition(form, entry.id), (form => form), setEntryUpdated);
-  const entryDuration = computeNumberOfHours(moment.utc(entry.startDateTime), moment.utc(entry.endDateTime));
+  const entryDuration = entry.numberOfHours;
   useEffect(() => {
     if (entryUpdated) {
       message.success('Entry was updated');
@@ -154,6 +152,7 @@ const EditEntryForm = ({date, form, timeSheets, onSuccess, onCancel, entry, numb
       >
         <TitleSection title='Edit task'/>
         <Form.Item name="date" noStyle={true}>
+          <Input hidden={true}/>
         </Form.Item>
 
         <Form.Item label="Description:" name="comment" rules={[{required: true}]}>
@@ -191,6 +190,7 @@ const EditEntryForm = ({date, form, timeSheets, onSuccess, onCancel, entry, numb
           </Col>
 
           <Form.Item name="startDateTime" noStyle={true}>
+            <Input hidden={true}/>
           </Form.Item>
 
           <Col className="gutter-row" span={9}>
@@ -206,7 +206,7 @@ const EditEntryForm = ({date, form, timeSheets, onSuccess, onCancel, entry, numb
                     );
                   default:
                     return (
-                      <Form.Item name="numberHours" noStyle={true}>
+                      <Form.Item name="numberOfHours" noStyle={true}>
                         <Input hidden={true}/>
                       </Form.Item>
                     );
@@ -235,11 +235,9 @@ EditEntryForm.propTypes = {
     id: PropTypes.number.isRequired,
     comment: PropTypes.string.isRequired,
     billable: PropTypes.bool,
-    timeSheetId: PropTypes.number.isRequired,
-    isMorning: PropTypes.bool.isRequired,
-    startDateTime: PropTypes.object.isRequired,
-    endDateTime: PropTypes.object.isRequired,
+    startDateTime: PropTypes.string.isRequired,
+    numberOfHours: PropTypes.number.isRequired
   }).isRequired,
-  numberOfHoursForDay: PropTypes.array
+  numberOfHoursForDay: PropTypes.number
 };
 export default EditEntryForm;

--- a/frontend/src/components/TimeEntry/EditEntryForm.js
+++ b/frontend/src/components/TimeEntry/EditEntryForm.js
@@ -43,13 +43,12 @@ const initialValues = (defaultDate, entry, timeSheetId) => {
     startDateTime: moment.utc(entry.startDateTime),
     numberOfHours: entry.numberOfHours
   };
-  const numberOfHours = new Array(newEntry.numberOfHours);
   return {
     'comment': newEntry.comment,
     'timeSheetId': timeSheetId,
     'date': moment.utc(newEntry.startDateTime, 'YYYY-MM-DD'),
     'startDateTime': newEntry.startDateTime,
-    'timeUnit' : computeTimeUnit(numberOfHours),
+    'timeUnit' : computeTimeUnit(newEntry.numberOfHours),
     'numberOfHours': newEntry.numberOfHours
   };
 };

--- a/frontend/src/components/TimeEntry/SelectHoursComponent.js
+++ b/frontend/src/components/TimeEntry/SelectHoursComponent.js
@@ -26,10 +26,10 @@ const SelectHoursComponent = ({numberOfHoursForDay, entryDuration}) => {
     if(entryDuration){
       return parseInt(hour) + (parseInt(numberOfHoursForDay) - entryDuration) > 8;
     }
-    return parseInt(hour) + parseInt(numberOfHoursForDay) > 8;
+    return parseInt(hour) + numberOfHoursForDay > 8;
   };
   return (
-    <Form.Item name="numberHours" label="Number of hours:" rules={[{required: true}]}>
+    <Form.Item name="numberOfHours" label="Number of hours:" rules={[{required: true}]}>
       <Select
         showSearch
       >
@@ -39,7 +39,7 @@ const SelectHoursComponent = ({numberOfHoursForDay, entryDuration}) => {
   );
 };
 SelectHoursComponent.propTypes = {
-  numberOfHoursForDay: PropTypes.array.isRequired,
+  numberOfHoursForDay: PropTypes.number.isRequired,
   entryDuration: PropTypes.number,
 };
 

--- a/frontend/src/components/TimeEntry/SelectHoursComponent.js
+++ b/frontend/src/components/TimeEntry/SelectHoursComponent.js
@@ -26,7 +26,7 @@ const SelectHoursComponent = ({numberOfHoursForDay, entryDuration}) => {
     if(entryDuration){
       return parseInt(hour) + (parseInt(numberOfHoursForDay) - entryDuration) > 8;
     }
-    return parseInt(hour) + numberOfHoursForDay > 8;
+    return parseInt(hour) + parseInt(numberOfHoursForDay) > 8;
   };
   return (
     <Form.Item name="numberOfHours" label="Number of hours:" rules={[{required: true}]}>

--- a/frontend/src/components/TimeEntry/ShowTimeEntry.js
+++ b/frontend/src/components/TimeEntry/ShowTimeEntry.js
@@ -21,17 +21,8 @@ import {Button} from 'antd';
 import Tooltip from 'antd/lib/tooltip';
 import {ClockCircleOutlined, DeleteOutlined, CopyOutlined, EditOutlined} from '@ant-design/icons';
 
-const moment = require('moment');
-
 const ShowTimeEntry = ({entry, onClickEdit}) => {
-  const start = moment(entry.startDateTime).utc();
-  const end = moment(entry.endDateTime).utc();
-
-  const duration = moment.duration(end.diff(start));
-  const date = start.clone();
-  date.set({
-    hour: duration.asHours()
-  });
+  const duration = entry.numberOfHours;
 
   return (
     <div className="tk_TaskInfoGen">
@@ -40,7 +31,7 @@ const ShowTimeEntry = ({entry, onClickEdit}) => {
         <div className="tk_TaskInfoMiddle">
           <div>
             <p>{entry.project ? entry.project.name : ''}</p>
-            <p><ClockCircleOutlined />{date.format('hh:mm')}</p>
+            <p><ClockCircleOutlined />{duration}</p>
           </div>
           <div>
             <Tooltip title="Edit" key="edit">
@@ -68,7 +59,7 @@ ShowTimeEntry.propTypes = {
       name: PropTypes.string.isRequired,
     }).isRequired,
     startDateTime: PropTypes.string.isRequired,
-    endDateTime: PropTypes.string.isRequired,
+    numberOfHours: PropTypes.number.isRequired
   }),
   onClickEdit: PropTypes.func.isRequired // () => set the mode to 'edit', the mode can be 'view', 'add' or 'edit'
 };

--- a/frontend/src/components/TimeEntry/TimeEntry.js
+++ b/frontend/src/components/TimeEntry/TimeEntry.js
@@ -19,7 +19,6 @@ import './TimeEntry.less';
 import {Badge} from 'antd';
 import {ClockCircleOutlined} from '@ant-design/icons';
 import PropTypes from 'prop-types';
-import {computeNumberOfHours} from '../../utils/momentUtils';
 import moment from 'moment';
 
 const computeSize = (nbHours) => {
@@ -28,12 +27,7 @@ const computeSize = (nbHours) => {
 };
 const TimeEntry = ({entry, onClick}) => {
   const start = moment(entry.startDateTime).utc();
-  const end = moment(entry.endDateTime).utc();
-  const date = start.clone();
-  const hours = computeNumberOfHours(start, end);
-  date.set({
-    hour: hours
-  });
+  const hours = entry.numberOfHours;
   const size = computeSize(hours);
   return (
     <div className="tk_TaskCard" style={{height: `${size}px`}}
@@ -45,7 +39,7 @@ const TimeEntry = ({entry, onClick}) => {
         />
         <p>{(entry && entry.project && entry.project.name) ? entry.project.name : ''}</p>
       </div>
-      <p><ClockCircleOutlined/>{date.format('hh:mm')}</p>
+      <p><ClockCircleOutlined/>{hours}</p>
     </div>
   );
 };
@@ -57,7 +51,7 @@ TimeEntry.propTypes = {
       name: PropTypes.string.isRequired,
     }).isRequired,
     startDateTime: PropTypes.string.isRequired,
-    endDateTime: PropTypes.string.isRequired,
+    numberOfHours: PropTypes.number.isRequired,
   }),
   onClick: PropTypes.func.isRequired
 };

--- a/frontend/src/utils/momentUtils.js
+++ b/frontend/src/utils/momentUtils.js
@@ -106,10 +106,7 @@ const userEventsDurationPerDay = (userEvents, date) => {
 const timeEntriesDuration = (timeEntries) => {
   if(timeEntries){
     return _.sumBy(timeEntries, function(entry){
-      const start = moment(entry.startDateTime).utc();
-      const end = moment(entry.endDateTime).utc();
-      const duration = moment.duration(end.diff(start));
-      return duration.asHours();
+      return entry.numberOfHours;
     });
   }
   return 0;

--- a/frontend/src/utils/momentUtils.test.js
+++ b/frontend/src/utils/momentUtils.test.js
@@ -198,44 +198,44 @@ test('totalHoursPerDay should return 0 for no entries', () =>{
 
 // eslint-disable-next-line
 test('totalHoursPerDay should return 8 for some entries', () =>{
-  const emptyEntries=[];
+  const someEntries=[];
   const emptyUserEvent=[];
-  emptyEntries.push({
-    startDateTime: moment.utc('2020-08-04T09:00:00Z'),
-    endDateTime: moment.utc('2020-08-04T11:00:00Z'),
+  someEntries.push({
+    startDate: moment.utc('2020-08-04T09:00:00Z'),
+    numberOfHours: 2
   });
-  emptyEntries.push({
-    startDateTime: moment.utc('2020-08-04T11:00:00Z'),
-    endDateTime: moment.utc('2020-08-04T13:00:00Z'),
+  someEntries.push({
+    startDate: moment.utc('2020-08-04T11:00:00Z'),
+    numberOfHours: 2
   });
-  emptyEntries.push({
-    startDateTime: moment.utc('2020-08-04T15:00:00Z'),
-    endDateTime: moment.utc('2020-08-04T17:00:00Z'),
+  someEntries.push({
+    startDate: moment.utc('2020-08-04T11:00:00Z'),
+    numberOfHours: 2
   });
-  emptyEntries.push({
-    startDateTime: moment.utc('2020-08-04T17:00:00Z'),
-    endDateTime: moment.utc('2020-08-04T19:00:00Z'),
+  someEntries.push({
+    startDate: moment.utc('2020-08-04T11:00:00Z'),
+    numberOfHours: 2
   });
-  const result = totalHoursPerDay(emptyUserEvent,'2020-08-04',emptyEntries);
+  const result = totalHoursPerDay(emptyUserEvent,'2020-08-04',someEntries);
   // eslint-disable-next-line
   expect(result).toBe(8);
 });
 
 // eslint-disable-next-line
-test('totalHoursPerDay should return 3 hours for 2 entries that overlaps each other by one hour', () =>{
-  const emptyEntries=[];
+test('totalHoursPerDay should return a total for entries event if the 2 event are not on the same day...', () =>{
+  const timeEntries=[];
   const emptyUserEvent=[];
-  emptyEntries.push({
-    startDateTime: moment.utc('2020-08-04T09:00:00Z'),
-    endDateTime: moment.utc('2020-08-04T11:00:00Z'),
+  timeEntries.push({
+    startDate: moment.utc('2020-08-04'),
+    numberOfHours: 2
   });
-  emptyEntries.push({
-    startDateTime: moment.utc('2020-08-04T10:00:00Z'),
-    endDateTime: moment.utc('2020-08-04T11:00:00Z'),
+  timeEntries.push({
+    startDate: moment.utc('2020-08-24'),
+    numberOfHours: 2
   });
-  const result = totalHoursPerDay(emptyUserEvent,'2020-08-04',emptyEntries);
+  const result = totalHoursPerDay(emptyUserEvent,'2020-08-04',timeEntries);
   // eslint-disable-next-line
-  expect(result).toBe(3);
+  expect(result).toBe(4);
 });
 
 // eslint-disable-next-line

--- a/src/main/java/fr/lunatech/timekeeper/models/time/TimeEntry.java
+++ b/src/main/java/fr/lunatech/timekeeper/models/time/TimeEntry.java
@@ -40,6 +40,6 @@ public class TimeEntry extends PanacheEntityBase {
     public LocalDateTime startDateTime;
 
     @NotNull
-    public LocalDateTime endDateTime;
+    public Integer numberOfHours;
 
 }

--- a/src/main/java/fr/lunatech/timekeeper/services/TimeEntryService.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/TimeEntryService.java
@@ -50,7 +50,7 @@ public class TimeEntryService {
         }
         try {
             timeEntry.persistAndFlush();
-            timeEntriesNumberPerHoursGauge.incrementGauges(request.getNumberHours());
+            timeEntriesNumberPerHoursGauge.incrementGauges(request.getNumberOfHours());
         } catch (PersistenceException pe) {
             throw new CreateResourceException("TimeEntry was not created due to constraint violation");
         }
@@ -62,10 +62,10 @@ public class TimeEntryService {
         logger.debug("Modify timeEntry for id={} with {}, {}", timeSheetId, request, ctx);
         Optional<TimeEntry> timeEntryOptional = findById(timeEntryId, ctx);
         timeEntryOptional.ifPresent(timeEntry -> {
-            int oldNumberOfHours = TimeKeeperDateUtils.numberOfHoursBetween(timeEntry.startDateTime, timeEntry.endDateTime).intValue();
-            if (oldNumberOfHours != request.getNumberHours()) {
+            int oldNumberOfHours = timeEntry.numberOfHours;
+            if (oldNumberOfHours != request.getNumberOfHours()) {
                 timeEntriesNumberPerHoursGauge.decrementGauges(oldNumberOfHours);
-                timeEntriesNumberPerHoursGauge.incrementGauges(request.getNumberHours());
+                timeEntriesNumberPerHoursGauge.incrementGauges(request.getNumberOfHours());
             }
         });
         return timeEntryOptional

--- a/src/main/java/fr/lunatech/timekeeper/services/requests/TimeEntryRequest.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/requests/TimeEntryRequest.java
@@ -38,16 +38,16 @@ public class TimeEntryRequest {
     private final LocalDateTime startDateTime;
 
     @NotNull
-    private final Integer numberHours;
+    private final Integer numberOfHours;
 
     public TimeEntryRequest(
             @NotBlank String comment,
             @NotNull LocalDateTime startDateTime,
-            @NotNull Integer numberHours
+            @NotNull Integer hours
     ) {
         this.comment = comment;
         this.startDateTime = startDateTime;
-        this.numberHours = numberHours;
+        this.numberOfHours = hours;
     }
 
     public TimeEntry unbind(
@@ -67,7 +67,7 @@ public class TimeEntryRequest {
     ) {
         timeEntry.comment = getComment();
         timeEntry.startDateTime = getStartDateTime();
-        timeEntry.endDateTime = getStartDateTime().plusHours(getNumberHours());
+        timeEntry.numberOfHours = getNumberOfHours();
         timeEntry.timeSheet = findTimeSheet.apply(timeSheetId, ctx).orElseThrow(() -> new IllegalEntityStateException("TimeSheet not found for id " + timeSheetId));
         return timeEntry;
     }
@@ -80,8 +80,8 @@ public class TimeEntryRequest {
         return startDateTime;
     }
 
-    public Integer getNumberHours() {
-        return numberHours;
+    public Integer getNumberOfHours() {
+        return numberOfHours;
     }
 
     @Override
@@ -89,7 +89,7 @@ public class TimeEntryRequest {
         return "TimeEntryRequest{" +
                 "comment='" + comment + '\'' +
                 ", startDateTime=" + startDateTime +
-                ", numberHours=" + numberHours +
+                ", numberOfHours=" + numberOfHours +
                 '}';
     }
 }

--- a/src/main/java/fr/lunatech/timekeeper/services/responses/TimeSheetResponse.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/responses/TimeSheetResponse.java
@@ -110,19 +110,18 @@ public class TimeSheetResponse {
         public final LocalDateTime startDateTime;
 
         @NotNull
-        @JsonFormat(pattern = TimeKeeperDateFormat.DEFAULT_DATE_TIME_PATTERN)
-        public final LocalDateTime endDateTime;
+        public final Integer numberOfHours;
 
         public TimeEntryResponse(
                 @NotNull Long id,
                 @NotNull String comment,
                 @NotNull LocalDateTime startDateTime,
-                @NotNull LocalDateTime endDateTime
+                @NotNull Integer numberOfHours
         ) {
             this.id = id;
             this.comment = comment;
             this.startDateTime = startDateTime;
-            this.endDateTime = endDateTime;
+            this.numberOfHours = numberOfHours;
         }
 
         public static TimeSheetResponse.TimeEntryResponse bind(@NotNull TimeEntry timeEntry) {
@@ -130,7 +129,7 @@ public class TimeSheetResponse {
                     timeEntry.id,
                     timeEntry.comment,
                     timeEntry.startDateTime,
-                    timeEntry.endDateTime
+                    timeEntry.numberOfHours
             );
         }
 

--- a/src/main/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtils.java
+++ b/src/main/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtils.java
@@ -143,14 +143,4 @@ public class TimeKeeperDateUtils {
         return inputDate -> inputDate.isAfter(firstDayOfFirstWeek.minusDays(1)) && inputDate.isBefore(lastDayOfLastWeek.plusDays(1));
     }
 
-    /**
-     * Compute the number of hours between two LocalDateTime
-     * @param start
-     * @param end
-     * @return the number of hours between start and end
-     */
-    public static Long numberOfHoursBetween(LocalDateTime start, LocalDateTime end) {
-        if(start.isAfter(end)) throw new IllegalStateException("The start date is after end date ");
-        return Duration.between(start, end).toHours();
-    }
 }

--- a/src/main/java/fr/lunatech/timekeeper/timeutils/TimeSheetUtils.java
+++ b/src/main/java/fr/lunatech/timekeeper/timeutils/TimeSheetUtils.java
@@ -18,23 +18,24 @@ package fr.lunatech.timekeeper.timeutils;
 
 import fr.lunatech.timekeeper.models.time.TimeSheet;
 
-import java.time.Duration;
-
 public class TimeSheetUtils {
 
     private static final int NUMBER_OF_HOURS_IN_A_DAY = 8;
     private static final int NUMBER_OF_HOURS_IN_HALF_A_DAY = 4;
 
+    private TimeSheetUtils() {
+    }
+
     public static Long computeLeftOver(TimeSheet sheet) {
         if (null != sheet.maxDuration && sheet.maxDuration > 0) {
             // Early exit if no entry : left = maxDuration
-            if(sheet.entries == null || sheet.entries.isEmpty()){
+            if (sheet.entries == null || sheet.entries.isEmpty()) {
                 return sheet.maxDuration.longValue();
             }
 
             long consumedHours = sheet.entries.stream()
-                            .mapToLong(timeEntry -> Duration.between(timeEntry.startDateTime, timeEntry.endDateTime).toHours())
-                            .sum();
+                    .mapToLong(timeEntry -> timeEntry.numberOfHours)
+                    .sum();
 
             // Compute what's left based on durationUnit type (see constant)
             if (sheet.durationUnit != null) {
@@ -45,6 +46,8 @@ public class TimeSheetUtils {
                         return ((sheet.maxDuration * NUMBER_OF_HOURS_IN_HALF_A_DAY) - consumedHours) / NUMBER_OF_HOURS_IN_A_DAY;
                     case HOURLY:
                         return (sheet.maxDuration - consumedHours) / NUMBER_OF_HOURS_IN_A_DAY;
+                    default:
+                        throw new IllegalStateException("Invalid duration unit for sheet=" + sheet);
                 }
             } else {
                 // if no durationUnit let's consider it's a day based duration

--- a/src/main/resources/db/migration/V16__revert_update_on_timesheets.sql
+++ b/src/main/resources/db/migration/V16__revert_update_on_timesheets.sql
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Lunatech S.A.S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE timeentries ADD COLUMN numberofhours int4 default 0;
+
+/*
+-- Please note that H2 does not support the follow SQL statement since DATE() function does not exist with H2
+UPDATE timeentries as T1
+SET  numberOfHours = (select EXTRACT(EPOCH FROM (enddatetime_deprecated - startdatetime ))/3600  as diff_time_hours from timeentries T3 WHERE T3.id = T1.id);
+
+-- We can then drop enddatetime once the data are migrated
+ALTER TABLE timeentries DROP COLUMN enddatetime_deprecated;
+ */
+ALTER TABLE timeentries RENAME COLUMN enddatetime TO enddatetime_deprecated;

--- a/src/test/java/fr/lunatech/timekeeper/resources/PersonalTimesheetsResourceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/resources/PersonalTimesheetsResourceTest.java
@@ -166,9 +166,9 @@ class PersonalTimesheetsResourceTest {
         LocalDateTime notIncludedDayDateTime = LocalDateTime.of(2020, 6, 28, 9, 0);
         TimeEntryRequest notIncludedDay = new TimeEntryRequest("Today, I did this test", notIncludedDayDateTime, 8);
 
-        TimeSheetResponse.TimeEntryResponse entryResponseOnFirstDateExpected = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I did this test", firstDateTime, firstDateTime.plusHours(8));
-        TimeSheetResponse.TimeEntryResponse entryResponseOnLastDateExpected = new TimeSheetResponse.TimeEntryResponse(2L, "Today, I did this test", lastDateTime, lastDateTime.plusHours(8));
-        TimeSheetResponse.TimeEntryResponse includedDayResponse = new TimeSheetResponse.TimeEntryResponse(3L, "Today, I did this test", includedDayDateTime, includedDayDateTime.plusHours(8));
+        TimeSheetResponse.TimeEntryResponse entryResponseOnFirstDateExpected = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I did this test", firstDateTime, 8);
+        TimeSheetResponse.TimeEntryResponse entryResponseOnLastDateExpected = new TimeSheetResponse.TimeEntryResponse(2L, "Today, I did this test", lastDateTime, 8);
+        TimeSheetResponse.TimeEntryResponse includedDayResponse = new TimeSheetResponse.TimeEntryResponse(3L, "Today, I did this test", includedDayDateTime, 8);
         var timeEntriesExpected = List.of(entryResponseOnFirstDateExpected,
                 entryResponseOnLastDateExpected,
                 includedDayResponse);
@@ -268,17 +268,16 @@ class PersonalTimesheetsResourceTest {
         );
         String commentDay = "I worked on Disney content API for 8h";
         LocalDateTime startDay1 = LocalDateTime.of(2020, 6, 18, 10, 0);
-        LocalDateTime endDay1 = LocalDateTime.of(2020, 6, 18, 18, 0);
         LocalDateTime startDay2 = LocalDateTime.of(2020, 6, 19, 8, 0);
-        LocalDateTime endDay2 = LocalDateTime.of(2020, 6, 19, 16, 0);
+
         TimeEntryRequest jimmyEntry1 = new TimeEntryRequest(commentDay, startDay1, 8);
         TimeEntryRequest jimmyEntry2 = new TimeEntryRequest(commentDay, startDay2, 8);
         update(updatedTimeSheet, TimeSheetDef.uriPlusId(1L), jimmyToken);
         create(1L, jimmyEntry1, jimmyToken);
         create(1L, jimmyEntry2, jimmyToken);
 
-        TimeSheetResponse.TimeEntryResponse jimmyEntryDay1Response = new TimeSheetResponse.TimeEntryResponse(1L, commentDay, startDay1, endDay1);
-        TimeSheetResponse.TimeEntryResponse jimmyEntryDay2Response = new TimeSheetResponse.TimeEntryResponse(2L, commentDay, startDay2, endDay2);
+        TimeSheetResponse.TimeEntryResponse jimmyEntryDay1Response = new TimeSheetResponse.TimeEntryResponse(1L, commentDay, startDay1, 8);
+        TimeSheetResponse.TimeEntryResponse jimmyEntryDay2Response = new TimeSheetResponse.TimeEntryResponse(2L, commentDay, startDay2, 8);
 
         final var timesheet = new TimeSheetResponse(1L, projectResponse, jimmy.getId(), TimeUnit.HOURLY, true, null, 10, TimeUnit.DAY.toString(), List.of(jimmyEntryDay1Response, jimmyEntryDay2Response), 8L, START_DATE);
         WeekResponse response = new WeekResponse(LocalDate.of(2020, 6, 15), Collections.emptyList(), List.of(timesheet), new ArrayList<>());

--- a/src/test/java/fr/lunatech/timekeeper/resources/TimeEntryResourceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/resources/TimeEntryResourceTest.java
@@ -94,7 +94,7 @@ class TimeEntryResourceTest {
         create(2L, today, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I did this test", startDateTime, startDateTime.withHour(17).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I did this test", startDateTime, 8);
 
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
@@ -126,7 +126,7 @@ class TimeEntryResourceTest {
         create(2L, morning, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This morning, I did this test", startDateTime, startDateTime.withHour(13).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This morning, I did this test", startDateTime, 4);
 
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
@@ -159,7 +159,7 @@ class TimeEntryResourceTest {
         create(2L, hour, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I did this test", start, end);
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I did this test", start, 1);
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
 
@@ -248,7 +248,7 @@ class TimeEntryResourceTest {
         update(updatedToday, location, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I updated this entry", startDateTime, startDateTime.withHour(17).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "Today, I updated this entry", startDateTime, 8);
 
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
@@ -283,7 +283,7 @@ class TimeEntryResourceTest {
         update(updatedMorning, location, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This morning, I updated this entry", startDateTime, startDateTime.withHour(13).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This morning, I updated this entry", startDateTime, 4);
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
 
@@ -317,7 +317,7 @@ class TimeEntryResourceTest {
         update(updatedHour, location, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I updated this entry", startDateTime, startDateTime.withHour(10).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I updated this entry", startDateTime, 1);
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
         var expected = timeKeeperTestUtils.toJson(expectedTimeSheetJimmy2);
@@ -350,7 +350,7 @@ class TimeEntryResourceTest {
         update(updatedHour, location, jimmyToken);
 
         // THEN
-        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I did this test", startDateTime, startDateTime.withHour(11).withMinute(0));
+        TimeSheetResponse.TimeEntryResponse expectedTimeEntry = new TimeSheetResponse.TimeEntryResponse(1L, "This hour, I did this test", startDateTime, 2);
         final var expectedTimeSheetJimmy2 = new TimeSheetResponse(2L, project, jimmy.getId(), TimeUnit.HOURLY, true, null, null, TimeUnit.DAY.toString(),
                 List.of(expectedTimeEntry), null, START_DATE);
 

--- a/src/test/java/fr/lunatech/timekeeper/services/AuthenticationContextTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/AuthenticationContextTest.java
@@ -232,7 +232,7 @@ class AuthenticationContextTest {
         TimeEntry timeEntry = new TimeEntry();
         timeEntry.id=999L;
         timeEntry.startDateTime= LocalDateTime.now();
-        timeEntry.endDateTime= LocalDateTime.now();
+        timeEntry.numberOfHours=8;
         timeEntry.timeSheet = timeSheet;
         timeEntry.comment = "??";
 
@@ -709,7 +709,7 @@ class AuthenticationContextTest {
         TimeEntry timeEntry = new TimeEntry();
         timeEntry.id=999L;
         timeEntry.startDateTime= LocalDateTime.now();
-        timeEntry.endDateTime= LocalDateTime.now();
+        timeEntry.numberOfHours = 8;
         timeEntry.timeSheet = timeSheet;
         timeEntry.comment = "??";
 
@@ -754,7 +754,7 @@ class AuthenticationContextTest {
         TimeEntry timeEntry = new TimeEntry();
         timeEntry.id=999L;
         timeEntry.startDateTime= LocalDateTime.now();
-        timeEntry.endDateTime= LocalDateTime.now();
+        timeEntry.numberOfHours = 8;
         timeEntry.timeSheet = timeSheet;
         timeEntry.comment = "??";
 
@@ -798,7 +798,7 @@ class AuthenticationContextTest {
         TimeEntry timeEntry = new TimeEntry();
         timeEntry.id=999L;
         timeEntry.startDateTime= LocalDateTime.now();
-        timeEntry.endDateTime= LocalDateTime.now();
+        timeEntry.numberOfHours = 8;
         timeEntry.timeSheet = timeSheet;
         timeEntry.comment = "??";
 
@@ -842,14 +842,13 @@ class AuthenticationContextTest {
         TimeEntry timeEntry = new TimeEntry();
         timeEntry.id=999L;
         timeEntry.startDateTime= LocalDateTime.now();
-        timeEntry.endDateTime= LocalDateTime.now();
+        timeEntry.numberOfHours = 4;
         timeEntry.timeSheet = timeSheet;
         timeEntry.comment = "??";
 
         AuthenticationContext tested = new AuthenticationContext(zeUser.id, organization, List.of(Profile.SUPER_ADMIN));
         assertTrue(tested.canCreate(timeEntry));
     }
-
 
     @Test
     void project_canJoin_should_return_true_for_public_project() {

--- a/src/test/java/fr/lunatech/timekeeper/services/responses/TimeSheetResponseTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/responses/TimeSheetResponseTest.java
@@ -49,23 +49,22 @@ class TimeSheetResponseTest {
         assertTrue(tested.filterToSixWeeksRange(2020,2).entries.isEmpty());
     }
 
-
     @Test
     void should_drop_entries_not_in_6_weeks_timerange(){
         TimeSheetResponse.TimeEntryResponse july14 = new TimeSheetResponse.TimeEntryResponse(1L,
                 "comment",
-                LocalDateTime.of(2020,7,14,9,00),
-                LocalDateTime.of(2020,7,14,17,00)
+                LocalDateTime.of(2020,7,14,9,0),
+                8
         );
         TimeSheetResponse.TimeEntryResponse august15 = new TimeSheetResponse.TimeEntryResponse(2L,
                 "comment",
-                LocalDateTime.of(2020,8,15,9,00),
-                LocalDateTime.of(2020,8,15,17,00)
+                LocalDateTime.of(2020,8,15,9,0),
+                8
         );
         TimeSheetResponse.TimeEntryResponse junePreviousYear = new TimeSheetResponse.TimeEntryResponse(3L,
                 "comment",
-                LocalDateTime.of(2019,6,14,9,00),
-                LocalDateTime.of(2019,6,14,13,00)
+                LocalDateTime.of(2019,6,14,9,0),
+                4
         );
 
         List<TimeSheetResponse.TimeEntryResponse> initialDates = List.of(july14,junePreviousYear,august15);
@@ -88,7 +87,6 @@ class TimeSheetResponseTest {
         assertEquals(expectedList, tested.filterToSixWeeksRange(2020,7).entries);
     }
 
-
     // Open the 2020 calendar on a Mac, go to the "Year" view and look at January 2020
     // We expected to see the last week of 2019 and the first week of february on the "6 weeks view" of january 2020
     @Test
@@ -96,27 +94,27 @@ class TimeSheetResponseTest {
         TimeSheetResponse.TimeEntryResponse december29 = new TimeSheetResponse.TimeEntryResponse(1L,
                 "comment",
                 LocalDateTime.of(2019,12,29,9,00),
-                LocalDateTime.of(2019,12,29,17,00)
+                8
         );
         TimeSheetResponse.TimeEntryResponse december30 = new TimeSheetResponse.TimeEntryResponse(2L,
                 "comment",
                 LocalDateTime.of(2019,12,30,9,00),
-                LocalDateTime.of(2019,12,30,17,00)
+                8
         );
         TimeSheetResponse.TimeEntryResponse january20 = new TimeSheetResponse.TimeEntryResponse(3L,
                 "comment",
                 LocalDateTime.of(2020,1,20,9,00),
-                LocalDateTime.of(2020,1,20,17,00)
+                8
         );
         TimeSheetResponse.TimeEntryResponse february9 = new TimeSheetResponse.TimeEntryResponse(4L,
                 "comment",
                 LocalDateTime.of(2020,2,9,9,00),
-                LocalDateTime.of(2020,2,9,13,00)
+                4
         );
         TimeSheetResponse.TimeEntryResponse february10 = new TimeSheetResponse.TimeEntryResponse(5L,
                 "comment",
                 LocalDateTime.of(2020,2,10,9,00),
-                LocalDateTime.of(2020,2,10,13,00)
+                4
         );
 
         List<TimeSheetResponse.TimeEntryResponse> initialDates = List.of(december29,december30,january20,february9,february10);

--- a/src/test/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtilsTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtilsTest.java
@@ -330,24 +330,4 @@ class TimeKeeperDateUtilsTest {
         assertEquals(expected, TimeKeeperDateUtils.adjustToFirstDayOfWeek(inputDate));
     }
 
-    @Test
-    void shouldReturnNumberOfHours() {
-        LocalDateTime start = LocalDateTime.of(2020, 7, 2, 9, 0, 0);
-        LocalDateTime end = LocalDateTime.of(2020, 7, 2, 13, 0, 0);
-        assertEquals(4, TimeKeeperDateUtils.numberOfHoursBetween(start, end));
-    }
-
-    @Test
-    void shouldReturnNumberOfHoursForTwoDifferentDates() {
-        LocalDateTime start = LocalDateTime.of(2020, 7, 1, 23, 0, 0);
-        LocalDateTime end = LocalDateTime.of(2020, 7, 2, 1, 0, 0);
-        assertEquals(2, TimeKeeperDateUtils.numberOfHoursBetween(start, end));
-    }
-
-    @Test
-    void shouldThrowsExceptionWhenStartIsAfterEnd() {
-        LocalDateTime start = LocalDateTime.of(2020, 7, 2, 10, 0, 0);
-        LocalDateTime end = LocalDateTime.of(2020, 7, 2, 9, 0, 0);
-        assertThrows(IllegalStateException.class, () -> TimeKeeperDateUtils.numberOfHoursBetween(start, end));
-    }
 }

--- a/src/test/java/fr/lunatech/timekeeper/timeutils/TimeSheetUtilsTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/timeutils/TimeSheetUtilsTest.java
@@ -18,7 +18,6 @@ package fr.lunatech.timekeeper.timeutils;
 
 import fr.lunatech.timekeeper.models.time.TimeEntry;
 import fr.lunatech.timekeeper.models.time.TimeSheet;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -48,12 +47,12 @@ class TimeSheetUtilsTest {
                 null,
                 10,
                 TimeUnit.DAY,
-                generateTestEntries(8,8L),
+                generateTestEntries(8, 8),
                 START_DATE
         );
 
         //THEN: only 2 hours left
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(2L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(2L));
     }
 
     @Test
@@ -74,7 +73,7 @@ class TimeSheetUtilsTest {
         );
 
         //THEN: 10 days left
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(10L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(10L));
     }
 
     @Test
@@ -90,12 +89,12 @@ class TimeSheetUtilsTest {
                 null,
                 4,
                 TimeUnit.HALFDAY,
-                generateTestEntries(1,8L),
+                generateTestEntries(1, 8),
                 START_DATE
         );
 
         //THEN: only 2 half day (1 day)
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(1L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(1L));
     }
 
     @Test
@@ -111,12 +110,12 @@ class TimeSheetUtilsTest {
                 null,
                 4,
                 TimeUnit.HALFDAY,
-                generateTestEntries(3,4L),
+                generateTestEntries(3, 4),
                 START_DATE
         );
 
         //THEN: only 1 half day left (rounded to 0 day)
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(0L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(0L));
     }
 
     @Test
@@ -132,12 +131,12 @@ class TimeSheetUtilsTest {
                 null,
                 20,
                 TimeUnit.HOURLY,
-                generateTestEntries(1,8L),
+                generateTestEntries(1, 8),
                 START_DATE
         );
 
         //THEN: only 12 hours left (1,5 day -> rounded 1 day)
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(1L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(1L));
     }
 
     @Test
@@ -153,7 +152,7 @@ class TimeSheetUtilsTest {
                 null,
                 8,
                 TimeUnit.HOURLY,
-                generateTestEntries(1,1L),
+                generateTestEntries(1, 1),
                 START_DATE
         );
 
@@ -174,12 +173,12 @@ class TimeSheetUtilsTest {
                 null,
                 2,
                 TimeUnit.DAY,
-                generateTestEntries(4,8L),
+                generateTestEntries(4, 8),
                 START_DATE
         );
 
         //THEN: the result is negative
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(-2L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(-2L));
     }
 
     @Test
@@ -188,8 +187,8 @@ class TimeSheetUtilsTest {
 
         //WHEN the user entry is incorrect
         TimeEntry timeEntry = new TimeEntry();
-        timeEntry.startDateTime =LocalDateTime.now().minusHours(8L);
-        timeEntry.endDateTime = LocalDateTime.now();
+        timeEntry.startDateTime =LocalDateTime.now();
+        timeEntry.numberOfHours = 8;
         TimeSheet timesheet = new TimeSheet(
                 null,
                 null,
@@ -203,7 +202,7 @@ class TimeSheetUtilsTest {
         );
 
         //THEN: only 0 hours left (rounded 0 day)
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(0L));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(0L));
     }
 
     @Test
@@ -219,12 +218,12 @@ class TimeSheetUtilsTest {
                 null,
                 null,
                 TimeUnit.HOURLY,
-                generateTestEntries(1,1L),
+                generateTestEntries(1, 1),
                 START_DATE
         );
 
         //THEN: no calculation are made
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(nullValue()));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(nullValue()));
     }
 
     @Test
@@ -240,12 +239,12 @@ class TimeSheetUtilsTest {
                 null,
                 -2,
                 TimeUnit.HOURLY,
-                generateTestEntries(1,1L),
+                generateTestEntries(1, 1),
                 START_DATE
         );
 
         //THEN: no calculation are made
-        assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(nullValue()));
+        assertThat(TimeSheetUtils.computeLeftOver(timesheet), is(nullValue()));
     }
 
     @Test
@@ -261,7 +260,7 @@ class TimeSheetUtilsTest {
                 null,
                 4,
                 null,
-                generateTestEntries(1,8L),
+                generateTestEntries(1, 8),
                 START_DATE
         );
 
@@ -269,14 +268,14 @@ class TimeSheetUtilsTest {
         assertThat(TimeSheetUtils.computeLeftOver(timesheet),is(3L));
     }
 
-    private List<TimeEntry> generateTestEntries (int numberOfEntry, long hourPerEntry){
+    private List<TimeEntry> generateTestEntries (int numberOfEntry, int hourPerEntry){
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime nowPlusSomeHours = now.plusHours(hourPerEntry);
+        if (hourPerEntry < 0) throw new IllegalStateException("Invalid duration");
         List<TimeEntry> entries = new ArrayList<>();
         for (int i = 0 ; i<numberOfEntry;i++) {
             TimeEntry entry = new TimeEntry();
             entry.startDateTime = now;
-            entry.endDateTime = nowPlusSomeHours;
+            entry.numberOfHours = hourPerEntry;
             entries.add(entry);
         }
         return entries;


### PR DESCRIPTION
Refactor the TimeEntry entity so that the entity uses `numberOfHours` as a duration, and not the `endDateTime`. Updated also the react part. 