### PR TITLE
Specific shell to build the app on Clever-cloud

### DIFF
--- a/frontend/clevercloud.sh
+++ b/frontend/clevercloud.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Configure this script to build the REACT app as a Clever-cloud CC_PRE_BUILD_HOOK
+# using the clever-cli
+# user@host > clever env set CC_PRE_BUILD_HOOK ./frontend/clevercloud.sh
+# See https://www.clever-cloud.com/blog/features/2019/10/21/ghost-hosting-clever-cloud/
+# I recommend also to use a dedicated 3XL instance to build the app
+export REACT_APP_QUARKUS_BACKEND=https://acceptance.api.timekeeper.lunatech.fr
+cd frontend || return
+yarn install
+yarn --max-old-space-size=4096 build

--- a/frontend/prod-server.js
+++ b/frontend/prod-server.js
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-const path = require('path')
-const express = require('express')
+const path = require('path');
+const express = require('express');
 const app = express(),
     DIST_DIR = __dirname + "/build/",
-    HTML_FILE = path.join(DIST_DIR, 'index.html')
-    app.use(express.static(DIST_DIR))
+    HTML_FILE = path.join(DIST_DIR, 'index.html');
+    app.use(express.static(DIST_DIR));
     app.get('*', (req, res) => {
         res.sendFile(HTML_FILE)
-    })
-const PORT = process.env.PORT || 8080
+    });
+const PORT = process.env.PORT || 8080;
 app.listen(PORT, () => {
     console.log(`TimeKeeper App started`)
-})
+});


### PR DESCRIPTION
Shell script used by Clever-cloud as a CC_PRE_BUILD_HOOK to package the React AntD application on a 3XL server. Once package, the app is executed on a very small « nano » instance (less than 10 eur/month)