### PR TITLE
TK-458 duplicate eventTemplate

### DIFF
--- a/frontend/src/components/Events/EditEventTemplateForm.js
+++ b/frontend/src/components/Events/EditEventTemplateForm.js
@@ -83,7 +83,8 @@ const EditEventTemplateForm = () => {
 
   const disabledDate = (current) => {
     // Can not select days before today and today
-    return current && current < moment().endOf('day');
+    //return current && current < moment().endOf('day');
+    return false;
   };
 
   function disabledTime(time, type) {

--- a/src/main/java/fr/lunatech/timekeeper/gauges/TimeEntriesNumberPerHoursGauge.java
+++ b/src/main/java/fr/lunatech/timekeeper/gauges/TimeEntriesNumberPerHoursGauge.java
@@ -3,6 +3,7 @@ package fr.lunatech.timekeeper.gauges;
 import io.quarkus.runtime.StartupEvent;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 

--- a/src/main/java/fr/lunatech/timekeeper/models/time/EventTemplate.java
+++ b/src/main/java/fr/lunatech/timekeeper/models/time/EventTemplate.java
@@ -70,10 +70,4 @@ public class EventTemplate extends PanacheEntityBase {
                 '}';
     }
 
-    public boolean isValid() {
-        if (startDateTime != null && endDateTime != null && startDateTime.isAfter(endDateTime)) {
-            throw new CreateResourceException("Cannot create an EventTemplate if startDateTime is after endDateTime");
-        }
-        return true;
-    }
 }

--- a/src/main/java/fr/lunatech/timekeeper/models/time/EventTemplate.java
+++ b/src/main/java/fr/lunatech/timekeeper/models/time/EventTemplate.java
@@ -17,7 +17,6 @@
 package fr.lunatech.timekeeper.models.time;
 
 import fr.lunatech.timekeeper.models.Organization;
-import fr.lunatech.timekeeper.resources.exceptions.CreateResourceException;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
 import javax.persistence.*;

--- a/src/main/java/fr/lunatech/timekeeper/resources/EventTemplateResource.java
+++ b/src/main/java/fr/lunatech/timekeeper/resources/EventTemplateResource.java
@@ -29,8 +29,10 @@ import org.eclipse.microprofile.metrics.annotation.Timed;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
+import javax.json.Json;
 import javax.validation.Valid;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
@@ -88,9 +90,13 @@ public class EventTemplateResource implements EventTemplateResourceApi {
     @Override
     @Counted(name = "countUpdateEvent", description = "Counts how many times the user to update an event on method 'updateEvent'")
     @Timed(name = "timeUpdateEvent", description = "Times how long it takes the user to update an event on method 'updateEvent'", unit = MetricUnits.MILLISECONDS)
-    public Response updateEvent(Long id, EventTemplateRequest request) {
-        return eventTemplateService.update(id, request, authentication.context())
-                .map(it -> Response.noContent().build())
-                .orElseThrow(() -> new NotFoundException(String.format("Event Template not found for id=%d", id)));
+    public Response updateEvent(Long eventTemplateId, EventTemplateRequest request) {
+        Long updatedUserEvents = eventTemplateService.update(eventTemplateId, request, authentication.context());
+        return Response.status(Response.Status.OK)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(Json.createObjectBuilder()
+                        .add("numberOfUpdatedUserEvents", String.format("%d", updatedUserEvents))
+                ).build();
+
     }
 }

--- a/src/main/java/fr/lunatech/timekeeper/resources/openapi/EventTemplateResourceApi.java
+++ b/src/main/java/fr/lunatech/timekeeper/resources/openapi/EventTemplateResourceApi.java
@@ -113,15 +113,15 @@ public interface EventTemplateResourceApi {
     @Tag(ref = "events")
     @APIResponses(value = {
             @APIResponse(
-                    responseCode = "204",
-                    description = "Event updated"
+                    responseCode = "200",
+                    description = "Returns the number of associated userEvents updated or created"
             ),
             @APIResponse(
                     responseCode = "404",
                     description = "EventTemplate not found"
             )
     })
-    Response updateEvent(@PathParam("id") Long id, @RequestBody EventTemplateRequest request);
+    Response updateEvent(@PathParam("id") Long eventTemplateId, @RequestBody EventTemplateRequest request);
 
 
 }

--- a/src/main/java/fr/lunatech/timekeeper/services/EventTemplateService.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/EventTemplateService.java
@@ -18,6 +18,7 @@ package fr.lunatech.timekeeper.services;
 
 import fr.lunatech.timekeeper.models.time.EventTemplate;
 import fr.lunatech.timekeeper.models.time.UserEvent;
+import fr.lunatech.timekeeper.resources.exceptions.CreateResourceException;
 import fr.lunatech.timekeeper.resources.exceptions.UpdateResourceException;
 import fr.lunatech.timekeeper.services.requests.EventTemplateRequest;
 import fr.lunatech.timekeeper.services.responses.EventTemplateResponse;
@@ -27,8 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.persistence.PersistenceException;
 import javax.transaction.Transactional;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -75,17 +76,26 @@ public class EventTemplateService {
         logger.debug("Create a new event template with {}, {}", request, ctx);
         final EventTemplate eventTemplate = request.unbind(ctx);
 
-        eventTemplate.isValid();
+        if (request.getStartDateTime() == null) {
+            throw new CreateResourceException("Cannot create an EventTemplate if startDateTime is null");
+        }
+        if (request.getEndDateTime() == null) {
+            throw new CreateResourceException("Cannot create an EventTemplate if endDateTime is null");
+        }
 
-        // by unbinding we also generate userEvent in db for each user
-        // user event attributes will be inherited from eventTemplate (startTime, etc.)
-        checkThatNoOtherEventSameNameSameDateAlreadyExists(
-                eventTemplate.name,
-                eventTemplate.id,
-                eventTemplate.startDateTime,
-                eventTemplate.endDateTime, ctx);
+        if (request.getStartDateTime().isAfter(request.getEndDateTime())) {
+            throw new CreateResourceException("Cannot create an EventTemplate if startDateTime is after endDateTime");
+        }
 
-        eventTemplate.persistAndFlush();
+        try {
+            eventTemplate.persistAndFlush();
+        }catch (PersistenceException pe){
+            if(pe.getCause() instanceof org.hibernate.exception.ConstraintViolationException && pe.getCause().getCause() instanceof  org.postgresql.util.PSQLException){
+                    logger.warn(String.format("SQL Exception : unable to persist this EventTemplate due to [%s]",pe.getCause().getCause().getMessage()) );
+                    throw new CreateResourceException("Cannot create EventTemplate due to database constraints. Check that no other eventTemplate with sameDate, same name already exists");
+            }
+            throw new CreateResourceException(String.format("Unable to persist this EventTemplate due to [%s]",pe.getMessage()));
+        }
 
         // Create a userEvent for each attendee using the userEventService
         if (!request.getAttendees().isEmpty()) {
@@ -104,25 +114,33 @@ public class EventTemplateService {
     public Optional<Long> update(Long eventId, EventTemplateRequest request, AuthenticationContext ctx) {
         logger.debug("Modify event template for for id={} with {}, {}", eventId, request, ctx);
 
-        // Request coming from frontend
-        final var newName = request.getName();
-        final var newStartTime = request.getStartDateTime();
-        final var newEndTime = request.getEndDateTime();
+        if (request.getStartDateTime() == null) {
+            throw new UpdateResourceException("Cannot update an EventTemplate if startDateTime is null");
+        }
+        if (request.getEndDateTime() == null) {
+            throw new UpdateResourceException("Cannot update an EventTemplate if endDateTime is null");
+        }
 
-        // early quit: eventTemplate doesn't exist
+        if (request.getStartDateTime().isAfter(request.getEndDateTime())) {
+            throw new UpdateResourceException("Cannot update an EventTemplate if startDateTime is after endDateTime");
+        }
+
         final Optional<EventTemplate> maybeEvent = findById(eventId, ctx);
 
         return maybeEvent.map(event -> {
-            checkThatNoOtherEventSameNameSameDateAlreadyExists(
-                    newName,
-                    event.id,
-                    newStartTime,
-                    newEndTime,
-                    ctx);
-
             // actually update the event
             EventTemplate eventTemplateUpdated = request.unbind(event, ctx);
-            eventTemplateUpdated.persistAndFlush();
+
+            try {
+                eventTemplateUpdated.persistAndFlush();
+            }catch (PersistenceException pe){
+                if(pe.getCause() instanceof org.hibernate.exception.ConstraintViolationException && pe.getCause().getCause() instanceof  org.postgresql.util.PSQLException){
+                    logger.warn(String.format("SQL Exception : unable to persist this EventTemplate due to [%s]",pe.getCause().getCause().getMessage()) );
+                    throw new CreateResourceException("Cannot create EventTemplate due to database constraints. Check that no other eventTemplate with sameDate, same name already exists");
+                }
+                throw new CreateResourceException(String.format("Unable to persist this EventTemplate due to [%s]",pe.getMessage()));
+            }
+
             logger.debug("Updated eventTemplate id={}", eventTemplateUpdated.id);
 
             // Create userEvent for each attendee using the userEventService
@@ -136,35 +154,9 @@ public class EventTemplateService {
         });
     }
 
-    protected void checkThatNoOtherEventSameNameSameDateAlreadyExists(String name, Long eventId, LocalDateTime startDateTime, LocalDateTime endDateTime, AuthenticationContext ctx) {
-        final var startDate = startDateTime.toLocalDate();
-        final var endDate = endDateTime.toLocalDate();
-        final var foundEvents = findByName(name, ctx)
-                .stream()
-                .filter(eventTemplate -> !eventTemplate.id.equals(eventId) &&
-                        eventTemplate.startDateTime.toLocalDate().isEqual(startDate) &&
-                        eventTemplate.endDateTime.toLocalDate().isEqual(endDate))
-                .findAny();
-
-        if (foundEvents.isPresent()) {
-            throw new UpdateResourceException(
-                    "Event with name: " + name +
-                            ", already exists with same start " + startDateTime.toLocalDate() +
-                            " and end " + endDateTime.toLocalDate() + " dates."
-            );
-        }
-    }
-
     private Optional<EventTemplate> findById(Long id, AuthenticationContext ctx) {
         return EventTemplate.<EventTemplate>findByIdOptional(id) //NOSONAR
                 .filter(ctx::canAccess);
-    }
-
-    private List<EventTemplate> findByName(String name, AuthenticationContext ctx) {
-        return EventTemplate.<EventTemplate>find("name", name) //NOSONAR
-                .stream()
-                .filter(ctx::canAccess)
-                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/fr/lunatech/timekeeper/services/EventTemplateService.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/EventTemplateService.java
@@ -136,7 +136,7 @@ public class EventTemplateService {
             }catch (PersistenceException pe){
                 if(pe.getCause() instanceof org.hibernate.exception.ConstraintViolationException && pe.getCause().getCause() instanceof  org.postgresql.util.PSQLException){
                     logger.warn(String.format("SQL Exception : unable to persist this EventTemplate due to [%s]",pe.getCause().getCause().getMessage()) );
-                    throw new CreateResourceException("Cannot create EventTemplate due to database constraints. Check that no other eventTemplate with sameDate, same name already exists");
+                    throw new UpdateResourceException("Cannot create EventTemplate due to database constraints. Check that no other eventTemplate with sameDate, same name already exists");
                 }
                 throw new CreateResourceException(String.format("Unable to persist this EventTemplate due to [%s]",pe.getMessage()));
             }

--- a/src/main/java/fr/lunatech/timekeeper/services/TimeEntryService.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/TimeEntryService.java
@@ -20,7 +20,6 @@ import fr.lunatech.timekeeper.gauges.TimeEntriesNumberPerHoursGauge;
 import fr.lunatech.timekeeper.models.time.TimeEntry;
 import fr.lunatech.timekeeper.resources.exceptions.CreateResourceException;
 import fr.lunatech.timekeeper.services.requests.TimeEntryRequest;
-import fr.lunatech.timekeeper.timeutils.TimeKeeperDateUtils;
 import io.quarkus.security.ForbiddenException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/fr/lunatech/timekeeper/services/UserEventService.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/UserEventService.java
@@ -12,8 +12,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
@@ -53,9 +56,9 @@ public class UserEventService {
         return userEvent.startDateTime.getYear() == year || userEvent.endDateTime.getYear() == year;
     }
 
-    protected List<User> findAllUsersFromEventTemplate(Long templateId){
-        return UserEvent.<UserEvent>stream("eventtemplate_id=?1",templateId) // NOSONAR
-                .map( userEvent -> userEvent.owner)
+    protected List<User> findAllUsersFromEventTemplate(Long templateId) {
+        return UserEvent.<UserEvent>stream("eventtemplate_id=?1", templateId) // NOSONAR
+                .map(userEvent -> userEvent.owner)
                 .collect(Collectors.toList());
     }
 
@@ -64,7 +67,7 @@ public class UserEventService {
                                                 AuthenticationContext ctx) {
         // Here we delete any userEvent that was previously created with this template.
         // If you remove a user from a template, it will delete the associated userEvent
-        UserEvent.<UserEvent>stream("eventtemplate_id=?1",eventTemplate.id) // NOSONAR
+        UserEvent.<UserEvent>stream("eventtemplate_id=?1", eventTemplate.id) // NOSONAR
                 .forEach(PanacheEntityBase::delete);
 
         if (userEventRequests.isEmpty()) {
@@ -78,5 +81,19 @@ public class UserEventService {
             updated++;
         }
         return updated;
+    }
+
+    /**
+     * Returns true if the specified user is available for the specified date range
+     *
+     * @param userId        cannot be null
+     * @param startDateTime is a valid startDateTime and cannot be null
+     * @param endDateTime   if specified, must be after startDateTime
+     * @return true if the user is available, otherwise returns false
+     */
+    public boolean isUserAvailableForDates(@NotNull Long userId, @NotNull LocalDateTime startDateTime, LocalDateTime endDateTime) {
+
+
+        return true;
     }
 }

--- a/src/main/java/fr/lunatech/timekeeper/services/UserEventService.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/UserEventService.java
@@ -62,14 +62,14 @@ public class UserEventService {
     public Long createOrUpdateFromEventTemplate(EventTemplate eventTemplate,
                                                 List<EventTemplateRequest.UserEventRequest> userEventRequests,
                                                 AuthenticationContext ctx) {
-        if (userEventRequests.isEmpty()) {
-            return 0L;
-        }
-
         // Here we delete any userEvent that was previously created with this template.
         // If you remove a user from a template, it will delete the associated userEvent
         UserEvent.<UserEvent>stream("eventtemplate_id=?1",eventTemplate.id) // NOSONAR
                 .forEach(PanacheEntityBase::delete);
+
+        if (userEventRequests.isEmpty()) {
+            return 0L;
+        }
 
         long updated = 0;
         for (var userEventRequest : userEventRequests) {

--- a/src/main/java/fr/lunatech/timekeeper/services/responses/MonthResponse.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/responses/MonthResponse.java
@@ -17,7 +17,6 @@
 package fr.lunatech.timekeeper.services.responses;
 
 import fr.lunatech.timekeeper.models.time.TimeSheet;
-import fr.lunatech.timekeeper.models.time.UserEvent;
 import fr.lunatech.timekeeper.timeutils.PublicHoliday;
 import fr.lunatech.timekeeper.timeutils.Week;
 

--- a/src/main/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtils.java
+++ b/src/main/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtils.java
@@ -17,7 +17,6 @@
 package fr.lunatech.timekeeper.timeutils;
 
 import java.time.DayOfWeek;
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -87,10 +87,10 @@ quarkus.log.console.enable=true
 quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %X %s%n
 %dev.quarkus.log.console.format=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %X %s%e%n
 quarkus.log.console.level=INFO
-%dev.quarkus.log.console.level=FINEST
+%dev.quarkus.log.console.level=FINE
 %dev.quarkus.log.console.color=true
 
-quarkus.log.category."io.quarkus".level=DEBUG
+quarkus.log.category."io.quarkus".level=WARN
 quarkus.log.category."fr.lunatech.timekeeper".level=DEBUG
 quarkus.log.category."fr.lunatech.timekeeper.resources".level=DEBUG
 quarkus.log.category."fr.lunatech.timekeeper.services".level=DEBUG
@@ -115,8 +115,6 @@ timekeeper.organizations."lunatech.com"=Lunatech COM
 timekeeper.organizations."lunatech.nl"=Lunatech NL
 timekeeper.organizations."lunatech.be"=Lunatech BE
 timekeeper.organizations."lunatech.fr"=Lunatech FR
-
-RestAssured.defaultParser = Parser.JSON;
 
 # Details to display git commit in the footer
 application.git.hash=${COMMIT_ID}

--- a/src/main/resources/db/migration/V17__event_template_unique_constraint.sql
+++ b/src/main/resources/db/migration/V17__event_template_unique_constraint.sql
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Lunatech S.A.S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- This statement does not work with H2.
+-- Use this SQL statement if you have duplicate event_template in your pgSQL DEV DB :
+/*
+DELETE
+from event_template
+WHERE event_template.ID NOT IN
+      (SELECT ID FROM (SELECT DISTINCT ON (startdatetime,enddatetime,name) * FROM event_template) as delete_q);
+*/
+ALTER TABLE event_template
+    ADD CONSTRAINT single_event_check UNIQUE (startdatetime, enddatetime, name);

--- a/src/test/java/fr/lunatech/timekeeper/models/time/EventTemplateTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/models/time/EventTemplateTest.java
@@ -16,30 +16,11 @@
 
 package fr.lunatech.timekeeper.models.time;
 
-import fr.lunatech.timekeeper.resources.exceptions.CreateResourceException;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EventTemplateTest {
-
-    @Test
-    void shouldValidateTwoDates() {
-        var tested = new EventTemplate();
-        tested.startDateTime = LocalDateTime.of(2020, 2, 29, 12, 23, 29);
-        tested.endDateTime = LocalDateTime.of(2020, 4, 2, 13, 29);
-        assertTrue(tested.isValid());
-    }
-
-    @Test
-    void shouldNotValidateEventTemplate() {
-        var tested = new EventTemplate();
-        tested.startDateTime = LocalDateTime.of(2020, 2, 29, 12, 23, 29);
-        tested.endDateTime = LocalDateTime.of(2018, 4, 2, 11, 29);
-        assertThrows(CreateResourceException.class, tested::isValid);
-    }
 
     @Test
     void shouldNotThrowAnyNpe() {

--- a/src/test/java/fr/lunatech/timekeeper/models/time/UserEventTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/models/time/UserEventTest.java
@@ -34,7 +34,6 @@ import javax.inject.Inject;
 import javax.transaction.*;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.util.Set;
 
 import static fr.lunatech.timekeeper.resources.KeycloakTestResource.getAdminAccessToken;
 import static fr.lunatech.timekeeper.resources.KeycloakTestResource.getUserAccessToken;

--- a/src/test/java/fr/lunatech/timekeeper/resources/EventTemplateResourceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/resources/EventTemplateResourceTest.java
@@ -325,8 +325,8 @@ class EventTemplateResourceTest {
         return new EventTemplateRequest(
                 eventName,
                 EVENT_DESCRIPTION,
-                THE_24_TH_JUNE_2020_AT_9_AM,
-                THE_24_TH_JUNE_2020_AT_5_PM,
+                THE_24_TH_JUNE_2020_AT_9_AM.withNano(0),
+                THE_24_TH_JUNE_2020_AT_5_PM.withNano(0),
                 Arrays.stream(usersId)
                         .sorted(Comparator.comparingLong(value -> (long)value))
                         .map(EventTemplateRequest.UserEventRequest::new)
@@ -340,8 +340,8 @@ class EventTemplateResourceTest {
                 expectedID,
                 eventName,
                 EVENT_DESCRIPTION,
-                THE_24_TH_JUNE_2020_AT_9_AM,
-                THE_24_TH_JUNE_2020_AT_5_PM,
+                THE_24_TH_JUNE_2020_AT_9_AM.withNano(0),
+                THE_24_TH_JUNE_2020_AT_5_PM.withNano(0),
                 attendees
         );
     }

--- a/src/test/java/fr/lunatech/timekeeper/services/EventTemplateServiceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/EventTemplateServiceTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020 Lunatech S.A.S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.lunatech.timekeeper.services;
+
+import com.google.common.collect.Lists;
+import fr.lunatech.timekeeper.models.Organization;
+import fr.lunatech.timekeeper.resources.KeycloakTestResource;
+import fr.lunatech.timekeeper.resources.exceptions.CreateResourceException;
+import fr.lunatech.timekeeper.services.requests.EventTemplateRequest;
+import fr.lunatech.timekeeper.services.responses.EventTemplateResponse;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.h2.H2DatabaseTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static fr.lunatech.timekeeper.resources.KeycloakTestResource.getAdminAccessToken;
+import static fr.lunatech.timekeeper.resources.utils.ResourceFactory.create;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@QuarkusTest
+@QuarkusTestResource(H2DatabaseTestResource.class)
+@QuarkusTestResource(KeycloakTestResource.class)
+@Tag("integration")
+class EventTemplateServiceTest {
+
+    @Inject
+    Flyway flyway;
+
+    @Inject
+    EventTemplateService eventTemplateService;
+
+    @AfterEach
+    void cleanUp() {
+        flyway.clean();
+        flyway.migrate();
+    }
+
+    private static final LocalDateTime START_DAY = LocalDateTime.of(2020, 1, 1, 8, 0);
+
+    @Test
+    void create_should_create_an_user_event() {
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+
+        EventTemplateRequest.UserEventRequest userEventRequest = new EventTemplateRequest.UserEventRequest(sam.getId());
+
+        EventTemplateRequest eventTemplateRequest = new EventTemplateRequest(
+                "request1",
+                "description1",
+                START_DAY,
+                START_DAY.plusHours(6),
+                Lists.newArrayList(userEventRequest)
+        );
+
+        Organization organization = new Organization();
+        organization.id = 1L;
+        organization.name = "name";
+        organization.tokenName = "tokenName";
+        organization.users = Collections.emptyList();
+        organization.projects = Collections.emptyList();
+        organization.clients = Collections.emptyList();
+
+        AuthenticationContext ctx = new AuthenticationContext(
+                sam.getId(),
+                organization,
+                Collections.emptyList()
+        );
+
+        List<EventTemplateResponse> eventsBefore = eventTemplateService.listAll(ctx);
+        eventTemplateService.create(eventTemplateRequest, ctx);
+        List<EventTemplateResponse> eventsAfter = eventTemplateService.listAll(ctx);
+
+        Assertions.assertTrue(eventsBefore.isEmpty());
+        Assertions.assertEquals(1, eventsAfter.size());
+    }
+
+    @Test
+    void should_reject_create_event_without_startdatetime() {
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+
+        EventTemplateRequest.UserEventRequest userEventRequest = new EventTemplateRequest.UserEventRequest(sam.getId());
+
+        EventTemplateRequest eventTemplateRequest = new EventTemplateRequest(
+                "an event with no startDateTime",
+                "description1",
+                null,
+                START_DAY.plusHours(6),
+                Lists.newArrayList(userEventRequest)
+        );
+        Organization organization = new Organization();
+        organization.id = 1L;
+        organization.name = "name";
+        organization.tokenName = "tokenName";
+        organization.users = Collections.emptyList();
+        organization.projects = Collections.emptyList();
+        organization.clients = Collections.emptyList();
+
+        AuthenticationContext ctx = new AuthenticationContext(
+                sam.getId(),
+                organization,
+                Collections.emptyList()
+        );
+
+        assertThrows(CreateResourceException.class, () -> eventTemplateService.create(eventTemplateRequest, ctx), "should throw a CreateException if the startDateTime is null");
+
+    }
+
+    @Test
+    void should_reject_create_event_without_enddatetime() {
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+
+        EventTemplateRequest.UserEventRequest userEventRequest = new EventTemplateRequest.UserEventRequest(sam.getId());
+
+        EventTemplateRequest eventTemplateRequest = new EventTemplateRequest(
+                "same name",
+                "description1",
+                START_DAY,
+                null,
+                Lists.newArrayList(userEventRequest)
+        );
+        Organization organization = new Organization();
+        organization.id = 1L;
+        organization.name = "name";
+        organization.tokenName = "tokenName";
+        organization.users = Collections.emptyList();
+        organization.projects = Collections.emptyList();
+        organization.clients = Collections.emptyList();
+
+        AuthenticationContext ctx = new AuthenticationContext(
+                sam.getId(),
+                organization,
+                Collections.emptyList()
+        );
+
+        assertThrows(CreateResourceException.class, () -> eventTemplateService.create(eventTemplateRequest, ctx), "should throw a CreateException if the endDateTime is null");
+    }
+
+    @Test
+    void should_reject_create_event_without_enddatetime_before_startdatetime() {
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+
+        EventTemplateRequest.UserEventRequest userEventRequest = new EventTemplateRequest.UserEventRequest(sam.getId());
+
+        EventTemplateRequest eventTemplateRequest = new EventTemplateRequest(
+                "same name",
+                "description1",
+                START_DAY,
+                START_DAY.minusHours(2),
+                Lists.newArrayList(userEventRequest)
+        );
+        Organization organization = new Organization();
+        organization.id = 1L;
+        organization.name = "name";
+        organization.tokenName = "tokenName";
+        organization.users = Collections.emptyList();
+        organization.projects = Collections.emptyList();
+        organization.clients = Collections.emptyList();
+
+        AuthenticationContext ctx = new AuthenticationContext(
+                sam.getId(),
+                organization,
+                Collections.emptyList()
+        );
+
+        assertThrows(CreateResourceException.class, () -> eventTemplateService.create(eventTemplateRequest, ctx), "should throw a CreateException if the endDateTime is null");
+    }
+}

--- a/src/test/java/fr/lunatech/timekeeper/services/EventTemplateServiceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/EventTemplateServiceTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import fr.lunatech.timekeeper.models.Organization;
 import fr.lunatech.timekeeper.resources.KeycloakTestResource;
 import fr.lunatech.timekeeper.resources.exceptions.CreateResourceException;
+import fr.lunatech.timekeeper.resources.exceptions.UpdateResourceException;
 import fr.lunatech.timekeeper.services.requests.EventTemplateRequest;
 import fr.lunatech.timekeeper.services.responses.EventTemplateResponse;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -243,5 +244,137 @@ class EventTemplateServiceTest {
         assertEquals(updatedEventTemplateRequest.getStartDateTime(), updatedEvent.getStartDateTime());
         assertEquals(updatedEventTemplateRequest.getEndDateTime(), updatedEvent.getEndDateTime());
         assertTrue(updatedEvent.getAttendees().isEmpty());
+    }
+
+    @Test
+    void create_should_not_update_if_start_date_is_null() {
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+
+        EventTemplateRequest.UserEventRequest userEventRequest = new EventTemplateRequest.UserEventRequest(sam.getId());
+
+        EventTemplateRequest eventTemplateRequest = new EventTemplateRequest(
+                "request1",
+                "description1",
+                START_DAY,
+                START_DAY.plusHours(6),
+                Lists.newArrayList(userEventRequest)
+        );
+
+        Organization organization = new Organization();
+        organization.id = 1L;
+        organization.name = "name";
+        organization.tokenName = "tokenName";
+        organization.users = Collections.emptyList();
+        organization.projects = Collections.emptyList();
+        organization.clients = Collections.emptyList();
+
+        AuthenticationContext ctx = new AuthenticationContext(
+                sam.getId(),
+                organization,
+                Collections.emptyList()
+        );
+
+        var maybeEventId = eventTemplateService.create(eventTemplateRequest, ctx);
+
+        assertTrue(maybeEventId.isPresent());
+
+        EventTemplateRequest updatedEventTemplateRequest = new EventTemplateRequest(
+                "updated name",
+                "updated descr",
+                null,
+                START_DAY.plusDays(1).plusHours(6),
+                Lists.newArrayList()
+        );
+        Long eventId = maybeEventId.get();
+        assertThrows(UpdateResourceException.class, () -> eventTemplateService.update(eventId, updatedEventTemplateRequest, ctx), "should throw a CreateException if the endDateTime is null");
+    }
+
+    @Test
+    void create_should_not_update_if_end_date_is_null() {
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+
+        EventTemplateRequest.UserEventRequest userEventRequest = new EventTemplateRequest.UserEventRequest(sam.getId());
+
+        EventTemplateRequest eventTemplateRequest = new EventTemplateRequest(
+                "request1",
+                "description1",
+                START_DAY,
+                START_DAY.plusHours(6),
+                Lists.newArrayList(userEventRequest)
+        );
+
+        Organization organization = new Organization();
+        organization.id = 1L;
+        organization.name = "name";
+        organization.tokenName = "tokenName";
+        organization.users = Collections.emptyList();
+        organization.projects = Collections.emptyList();
+        organization.clients = Collections.emptyList();
+
+        AuthenticationContext ctx = new AuthenticationContext(
+                sam.getId(),
+                organization,
+                Collections.emptyList()
+        );
+
+        var maybeEventId = eventTemplateService.create(eventTemplateRequest, ctx);
+
+        assertTrue(maybeEventId.isPresent());
+
+        EventTemplateRequest updatedEventTemplateRequest = new EventTemplateRequest(
+                "updated name",
+                "updated descr",
+                START_DAY.plusDays(1).plusHours(6),
+                null,
+                Lists.newArrayList()
+        );
+        Long eventId = maybeEventId.get();
+        assertThrows(UpdateResourceException.class, () -> eventTemplateService.update(eventId, updatedEventTemplateRequest, ctx), "should throw a CreateException if the endDateTime is null");
+    }
+
+    @Test
+    void create_should_not_update_if_end_date_is_beofre_start_date() {
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+
+        EventTemplateRequest.UserEventRequest userEventRequest = new EventTemplateRequest.UserEventRequest(sam.getId());
+
+        EventTemplateRequest eventTemplateRequest = new EventTemplateRequest(
+                "request1",
+                "description1",
+                START_DAY,
+                START_DAY.plusHours(6),
+                Lists.newArrayList(userEventRequest)
+        );
+
+        Organization organization = new Organization();
+        organization.id = 1L;
+        organization.name = "name";
+        organization.tokenName = "tokenName";
+        organization.users = Collections.emptyList();
+        organization.projects = Collections.emptyList();
+        organization.clients = Collections.emptyList();
+
+        AuthenticationContext ctx = new AuthenticationContext(
+                sam.getId(),
+                organization,
+                Collections.emptyList()
+        );
+
+        var maybeEventId = eventTemplateService.create(eventTemplateRequest, ctx);
+
+        assertTrue(maybeEventId.isPresent());
+
+        EventTemplateRequest updatedEventTemplateRequest = new EventTemplateRequest(
+                "updated name",
+                "updated descr",
+                START_DAY.plusHours(1),
+                START_DAY,
+                Lists.newArrayList()
+        );
+        Long eventId = maybeEventId.get();
+        assertThrows(UpdateResourceException.class, () -> eventTemplateService.update(eventId, updatedEventTemplateRequest, ctx), "should throw a CreateException if the endDateTime is null");
     }
 }

--- a/src/test/java/fr/lunatech/timekeeper/services/EventTemplateServiceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/EventTemplateServiceTest.java
@@ -37,6 +37,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static fr.lunatech.timekeeper.resources.KeycloakTestResource.getUserAccessToken;
 import static fr.lunatech.timekeeper.resources.KeycloakTestResource.getAdminAccessToken;
@@ -416,7 +417,7 @@ class EventTemplateServiceTest {
         var maybeEventId = eventTemplateService.create(eventTemplateRequest, ctx);
         assertTrue(maybeEventId.isPresent());
 
-        // WHEN jimmy is added to another eventTemplate
+        // WHEN jimmy is added to another eventTemplate but the new date overlaps each other
         EventTemplateRequest anotherEvent = new EventTemplateRequest(
                 "Hackbreakfast",
                 "An event in the morning with Jimmy",
@@ -425,8 +426,11 @@ class EventTemplateServiceTest {
                 Lists.newArrayList(userEventRequest)
         );
 
-        // THEN it should raise an exception
-        Long eventId = maybeEventId.get();
-        assertThrows(UpdateResourceException.class, () -> eventTemplateService.update(eventId, anotherEvent, ctx), "should throw a CreateException if the endDateTime is null");
+        // THEN
+        assertEquals(Optional.of(2L), eventTemplateService.create(anotherEvent, ctx), "Should create a 2nd userEvent");
+
+        Optional<EventTemplateResponse> response = eventTemplateService.getById(2L, ctx);
+        response.
+
     }
 }

--- a/src/test/java/fr/lunatech/timekeeper/services/UserEventServiceIntegrationTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/UserEventServiceIntegrationTest.java
@@ -52,7 +52,7 @@ class UserEventServiceIntegrationTest {
         UserResponse userSam = create(adminToken);
 
         //WHEN: an eventTemplate is created with the 1 attendee
-        EventTemplateRequest newEventTemplate = generateTestEventRequest("Event Name", 1L);
+        EventTemplateRequest newEventTemplate = generateTestEventRequest("Event Name 1", 1L);
         create(newEventTemplate,adminToken);
         var expected = userEventService.getEventsByUser(userSam.getId(), TimeKeeperDateUtils.getWeekNumberFromDate(THE_24_TH_JUNE_2020_AT_9_AM.toLocalDate()), 2020, TimeKeeperDateUtils::getWeekNumberFromDate);
 
@@ -66,7 +66,7 @@ class UserEventServiceIntegrationTest {
         UserResponse userSam = create(adminToken);
 
         //WHEN: an eventTemplate is created with the 1 attendee
-        EventTemplateRequest newEventTemplate = generateTestEventRequest("Event Name", 1L);
+        EventTemplateRequest newEventTemplate = generateTestEventRequest("Event Name 2", 1L);
         create(newEventTemplate,adminToken);
         var expected = userEventService.getEventsByUser(userSam.getId(), TimeKeeperDateUtils.getMonthNumberFromDate(THE_24_TH_JUNE_2020_AT_9_AM.toLocalDate()), 2020, TimeKeeperDateUtils::getMonthNumberFromDate);
 
@@ -80,7 +80,7 @@ class UserEventServiceIntegrationTest {
         UserResponse userSam = create(adminToken);
 
         //WHEN: an eventTemplate is created with the 1 attendee
-        EventTemplateRequest newEventTemplate = generateTestEventRequest("Event Name", 1L);
+        EventTemplateRequest newEventTemplate = generateTestEventRequest("Event Name 3", 1L);
         create(newEventTemplate,adminToken);
         var expected = List.of();
 
@@ -94,7 +94,7 @@ class UserEventServiceIntegrationTest {
         UserResponse userSam = create(adminToken);
 
         //WHEN: an eventTemplate is created with the 1 attendee
-        EventTemplateRequest newEventTemplate = generateTestEventRequest("Event Name", 1L);
+        EventTemplateRequest newEventTemplate = generateTestEventRequest("Event Name 4", 1L);
         create(newEventTemplate,adminToken);
         var expected = List.of();
         assertEquals(expected,userEventService.getEventsByUserForMonthNumber(userSam.getId(), TimeKeeperDateUtils.getMonthNumberFromDate(THE_24_TH_JUNE_2020_AT_9_AM.toLocalDate()) + 1, 2020));

--- a/src/test/java/fr/lunatech/timekeeper/services/UserEventServiceIntegrationTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/UserEventServiceIntegrationTest.java
@@ -1,12 +1,15 @@
 package fr.lunatech.timekeeper.services;
 
+import fr.lunatech.timekeeper.models.time.UserEvent;
 import fr.lunatech.timekeeper.resources.KeycloakTestResource;
 import fr.lunatech.timekeeper.services.requests.EventTemplateRequest;
+import fr.lunatech.timekeeper.services.responses.EventTemplateResponse;
 import fr.lunatech.timekeeper.services.responses.UserResponse;
 import fr.lunatech.timekeeper.timeutils.TimeKeeperDateUtils;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
@@ -14,14 +17,21 @@ import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static fr.lunatech.timekeeper.resources.KeycloakTestResource.getAdminAccessToken;
+import static fr.lunatech.timekeeper.resources.KeycloakTestResource.getUserAccessToken;
+import static fr.lunatech.timekeeper.resources.utils.ResourceDefinition.EventDef;
+import static fr.lunatech.timekeeper.resources.utils.ResourceDefinition.EventUsersDef;
 import static fr.lunatech.timekeeper.resources.utils.ResourceFactory.create;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static fr.lunatech.timekeeper.resources.utils.ResourceValidation.getValidation;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
 @QuarkusTestResource(H2DatabaseTestResource.class)
@@ -45,6 +55,18 @@ class UserEventServiceIntegrationTest {
         flyway.migrate();
     }
 
+    private EventTemplateRequest generateTestEventRequest(String eventName, Long... usersId){
+        return new EventTemplateRequest(
+                eventName,
+                EVENT_DESCRIPTION,
+                THE_24_TH_JUNE_2020_AT_9_AM,
+                THE_24_TH_JUNE_2020_AT_5_PM,
+                Arrays.stream(usersId)
+                        .sorted(Comparator.comparingLong(value -> (long)value))
+                        .map(EventTemplateRequest.UserEventRequest::new)
+                        .collect(Collectors.toList())
+        );
+    }
     @Test
     void shouldGetEventsByUserForAWeekNumber() {
         //Given
@@ -100,16 +122,104 @@ class UserEventServiceIntegrationTest {
         assertEquals(expected,userEventService.getEventsByUserForMonthNumber(userSam.getId(), TimeKeeperDateUtils.getMonthNumberFromDate(THE_24_TH_JUNE_2020_AT_9_AM.toLocalDate()) + 1, 2020));
     }
 
-    private EventTemplateRequest generateTestEventRequest(String eventName, Long... usersId){
-        return new EventTemplateRequest(
-                eventName,
-                EVENT_DESCRIPTION,
-                THE_24_TH_JUNE_2020_AT_9_AM,
-                THE_24_TH_JUNE_2020_AT_5_PM,
-                Arrays.stream(usersId)
-                        .sorted(Comparator.comparingLong(value -> (long)value))
-                        .map(EventTemplateRequest.UserEventRequest::new)
-                        .collect(Collectors.toList())
-        );
+
+    @Test
+    void shouldReturnTrueForTwoSeparateEvents() {
+        //WITH: Unique EventName
+        final String eventName = RandomStringUtils.randomAlphabetic(15);
+
+        //GIVEN: 2 user
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+        create(getUserAccessToken());
+
+        //WHEN: an eventTemplateRequest is created with SAM as an attendee
+        EventTemplateRequest newEventTemplate = generateTestEventRequest(eventName, sam.getId());
+        create(newEventTemplate, samToken);
+
+        //THEN isUserAvailableForDates return true for dates that are not overlapping the test event
+        LocalDateTime dateBefore = newEventTemplate.getStartDateTime().minusDays(1);
+        LocalDateTime endDateBefore = newEventTemplate.getEndDateTime().minusDays(1);
+        assertTrue(userEventService.isUserAvailableForDates(sam.getId(),dateBefore,endDateBefore));
+    }
+
+    @Test
+    void shouldReturnTrueForTwoSeparateEvents2() {
+        //WITH: Unique EventName
+        final String eventName = RandomStringUtils.randomAlphabetic(15);
+
+        //GIVEN: 2 user
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+        create(getUserAccessToken());
+
+        //WHEN: an eventTemplateRequest is created with SAM as an attendee
+        EventTemplateRequest newEventTemplate = generateTestEventRequest(eventName, sam.getId());
+        create(newEventTemplate, samToken);
+
+        //THEN isUserAvailableForDates return true for dates that are not overlapping the test event
+        LocalDateTime dateAfter = newEventTemplate.getStartDateTime().plusDays(1);
+        LocalDateTime endDateAfter = newEventTemplate.getEndDateTime().plusDays(1);
+        assertTrue(userEventService.isUserAvailableForDates(sam.getId(),dateAfter,endDateAfter));
+    }
+
+    @Test
+    void shouldReturnFalseForStartDateIdenticalButDifferentEndDate() {
+        //WITH: Unique EventName
+        final String eventName = RandomStringUtils.randomAlphabetic(15);
+
+        //GIVEN: 2 user
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+        create(getUserAccessToken());
+
+        //WHEN: an eventTemplateRequest is created with SAM as an attendee
+        EventTemplateRequest newEventTemplate = generateTestEventRequest(eventName, sam.getId());
+        create(newEventTemplate, samToken);
+
+        //THEN isUserAvailableForDates returns true as the endDate is just one hour after the previous event
+        LocalDateTime dateAfter = newEventTemplate.getStartDateTime();
+        LocalDateTime endDateAfter = newEventTemplate.getEndDateTime().minusHours(1);
+        assertFalse(userEventService.isUserAvailableForDates(sam.getId(),dateAfter,endDateAfter));
+    }
+
+    @Test
+    void shouldReturnFalseIfEvent2StartsBeforeAndEndBefore() {
+        //WITH: Unique EventName
+        final String eventName = RandomStringUtils.randomAlphabetic(15);
+
+        //GIVEN: 2 user
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+        create(getUserAccessToken());
+
+        //WHEN: an eventTemplateRequest is created with SAM as an attendee
+        EventTemplateRequest newEventTemplate = generateTestEventRequest(eventName, sam.getId());
+        create(newEventTemplate, samToken);
+
+        //THEN isUserAvailableForDates as the new Event start and end one hour before the event stored in DB
+        LocalDateTime startBefore = newEventTemplate.getStartDateTime().minusHours(1);
+        LocalDateTime endBefore = newEventTemplate.getEndDateTime().minusHours(1);
+        assertFalse(userEventService.isUserAvailableForDates(sam.getId(),startBefore,endBefore));
+    }
+
+    @Test
+    void shouldReturnFalseIfNewEventStartsAfter() {
+        //WITH: Unique EventName
+        final String eventName = RandomStringUtils.randomAlphabetic(15);
+
+        //GIVEN: 2 user
+        final String samToken = getAdminAccessToken();
+        var sam = create(samToken);
+        create(getUserAccessToken());
+
+        //WHEN: an eventTemplateRequest is created with SAM as an attendee
+        EventTemplateRequest newEventTemplate = generateTestEventRequest(eventName, sam.getId());
+        create(newEventTemplate, samToken);
+
+        //THEN isUserAvailableForDates as the new Event start and end one hour before the event stored in DB
+        LocalDateTime startBefore = newEventTemplate.getStartDateTime().plusHours(1);
+        LocalDateTime endBefore = newEventTemplate.getEndDateTime().plusHours(1);
+        assertFalse(userEventService.isUserAvailableForDates(sam.getId(),startBefore,endBefore));
     }
 }

--- a/src/test/java/fr/lunatech/timekeeper/services/UserEventServiceIntegrationTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/UserEventServiceIntegrationTest.java
@@ -9,8 +9,8 @@ import io.quarkus.test.h2.H2DatabaseTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.flywaydb.core.Flyway;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
 import java.time.LocalDateTime;

--- a/src/test/java/fr/lunatech/timekeeper/services/UserEventServiceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/UserEventServiceTest.java
@@ -6,8 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 class UserEventServiceTest {
@@ -122,4 +121,21 @@ class UserEventServiceTest {
 
         assertTrue(userEventService.validateYear(userEvent, 2020));
     }
+
+    @Test
+    void shouldThrowExceptionForNullUserId() {
+        UserEventService userEventService = new UserEventService();
+        var aDate=LocalDateTime.of(2020,02,1,9,0,0);
+        var otherDate=aDate.plusHours(3);
+        assertThrows(IllegalArgumentException.class , () -> userEventService.isUserAvailableForDates(null,aDate,otherDate));
+    }
+
+    @Test
+    void shouldThrowExceptionForStartDate() {
+        UserEventService userEventService = new UserEventService();
+        var aDate=LocalDateTime.of(2020,02,1,9,0,0);
+        var otherDate=aDate.plusHours(3);
+        assertThrows(IllegalArgumentException.class , () -> userEventService.isUserAvailableForDates(1L,null,otherDate));
+    }
+
 }

--- a/src/test/java/fr/lunatech/timekeeper/services/UserEventServiceTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/services/UserEventServiceTest.java
@@ -3,6 +3,7 @@ package fr.lunatech.timekeeper.services;
 import fr.lunatech.timekeeper.models.time.UserEvent;
 import fr.lunatech.timekeeper.timeutils.TimeKeeperDateUtils;
 import org.junit.jupiter.api.Test;
+
 import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtilsTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/timeutils/TimeKeeperDateUtilsTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
This PR introduces a database constraints on EventTemplate. An EventTemplate with same start/end date and same name should not be created (or updated). 
Panache and Hibernate ORM are triggered from the EventTemplateService, in a persistAndFlush() operation. There's no clean pattern or recommended usage of ConstraintsViolationException with Quarkus. Maybe this will be improved in a future version.