### PR TITLE
TK-484 - Add Organisation Id in UserEvent Model

### DIFF
--- a/src/main/java/fr/lunatech/timekeeper/models/time/UserEvent.java
+++ b/src/main/java/fr/lunatech/timekeeper/models/time/UserEvent.java
@@ -116,7 +116,7 @@ public class UserEvent extends PanacheEntityBase {
                 ", startDateTime=" + startDateTime +
                 ", endDateTime=" + endDateTime +
                 ", owner=" + owner.getFullName() +
-                ", organizationId=" + creator.getOrganization().id +
+                ", organization=" + creator.getOrganization().name +
                 '}';
     }
 }

--- a/src/main/java/fr/lunatech/timekeeper/models/time/UserEvent.java
+++ b/src/main/java/fr/lunatech/timekeeper/models/time/UserEvent.java
@@ -116,7 +116,7 @@ public class UserEvent extends PanacheEntityBase {
                 ", startDateTime=" + startDateTime +
                 ", endDateTime=" + endDateTime +
                 ", owner=" + owner.getFullName() +
-                ", organization=" + creator.getOrganization().name +
+                ", organization=" + organization.name +
                 '}';
     }
 }

--- a/src/main/java/fr/lunatech/timekeeper/models/time/UserEvent.java
+++ b/src/main/java/fr/lunatech/timekeeper/models/time/UserEvent.java
@@ -16,6 +16,7 @@
 
 package fr.lunatech.timekeeper.models.time;
 
+import fr.lunatech.timekeeper.models.Organization;
 import fr.lunatech.timekeeper.models.User;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 
@@ -68,6 +69,10 @@ public class UserEvent extends PanacheEntityBase {
     @NotNull
     public User creator;
 
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "organization_id")
+    public Organization organization;
+
     public UserEvent() {
 
     }
@@ -79,7 +84,8 @@ public class UserEvent extends PanacheEntityBase {
                      String description,
                      EventType type,
                      User user,
-                     User creator
+                     User creator,
+                     Organization organization
     ) {
         this.id = id;
         this.startDateTime = startDateTime;
@@ -89,6 +95,7 @@ public class UserEvent extends PanacheEntityBase {
         this.eventType = type;
         this.owner = user;
         this.creator = creator;
+        this.organization = organization;
     }
 
     @Null
@@ -109,6 +116,7 @@ public class UserEvent extends PanacheEntityBase {
                 ", startDateTime=" + startDateTime +
                 ", endDateTime=" + endDateTime +
                 ", owner=" + owner.getFullName() +
+                ", organizationId=" + creator.getOrganization().id +
                 '}';
     }
 }

--- a/src/main/java/fr/lunatech/timekeeper/services/requests/UserEventRequest.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/requests/UserEventRequest.java
@@ -84,6 +84,7 @@ public class UserEventRequest {
         userEvent.endDateTime = this.endDateTime;
         userEvent.owner = owner;
         userEvent.creator = creator;
+        userEvent.organization = creator.getOrganization();
         return userEvent;
     }
 

--- a/src/main/java/fr/lunatech/timekeeper/services/requests/UserEventRequest.java
+++ b/src/main/java/fr/lunatech/timekeeper/services/requests/UserEventRequest.java
@@ -111,6 +111,7 @@ public class UserEventRequest {
                 .orElseThrow(() -> new IllegalEntityStateException(String.format("Unknown User. userId=%s", getUserId())));
         userEvent.creator = eventTemplate.creator;
         userEvent.eventTemplate = eventTemplate;
+        userEvent.organization = eventTemplate.creator.getOrganization();
         return userEvent;
     }
 

--- a/src/main/resources/db/migration/V22__alter_user_event_to_add_organization_id.sql
+++ b/src/main/resources/db/migration/V22__alter_user_event_to_add_organization_id.sql
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Lunatech S.A.S
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE user_events DROP COLUMN IF EXISTS organization_id;
+
+ALTER TABLE user_events ADD COLUMN organization_id int8 constraint fk_user_events_organization_id references organizations on delete set null;

--- a/src/test/java/fr/lunatech/timekeeper/resources/utils/DataTestProvider.java
+++ b/src/test/java/fr/lunatech/timekeeper/resources/utils/DataTestProvider.java
@@ -82,7 +82,8 @@ public class DataTestProvider {
                 EVENT_DESCRIPTION,
                 EventType.PERSONAL,
                 user,
-                creator
+                creator,
+                creator.organization
         );
         return bind(userEvent);
     }

--- a/src/test/java/fr/lunatech/timekeeper/timeutils/WeekUtilsTest.java
+++ b/src/test/java/fr/lunatech/timekeeper/timeutils/WeekUtilsTest.java
@@ -180,7 +180,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user,
-                user
+                user,
+                user.getOrganization()
         );
         UserEventResponse userEventResponse = UserEventResponse.bind(userEvent);
         assertEquals(8L,
@@ -199,7 +200,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user,
-                user
+                user,
+                user.getOrganization()
         );
         UserEventResponse userEventResponse = UserEventResponse.bind(userEvent);
         assertEquals(2L,
@@ -218,7 +220,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user,
-                user
+                user,
+                user.getOrganization()
         );
         UserEventResponse userEventResponse = UserEventResponse.bind(userEvent);
         assertEquals(8L,
@@ -237,7 +240,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user,
-                user
+                user,
+                user.getOrganization()
         );
         final UserEvent userEvent2 = new UserEvent(
                 2L,
@@ -247,7 +251,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user,
-                user
+                user,
+                user.getOrganization()
         );
         UserEventResponse userEventResponse = UserEventResponse.bind(userEvent);
         UserEventResponse userEventResponse2 = UserEventResponse.bind(userEvent2);
@@ -268,7 +273,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user,
-                user
+                user,
+                user.getOrganization()
         );
         final UserEvent userEvent2 = new UserEvent(
                 2L,
@@ -278,7 +284,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user2,
-                user2
+                user2,
+                user2.getOrganization()
         );
         UserEventResponse userEventResponse = UserEventResponse.bind(userEvent);
         UserEventResponse userEventResponse2 = UserEventResponse.bind(userEvent2);
@@ -301,7 +308,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user,
-                user
+                user,
+                user.getOrganization()
         );
         UserEventResponse userEventResponse = UserEventResponse.bind(userEvent);
         TimeSheetResponse.TimeEntryResponse timeEntry1 = new TimeSheetResponse.TimeEntryResponse(
@@ -337,7 +345,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user,
-                user
+                user,
+                user.getOrganization()
         );
         UserEventResponse userEventResponse = UserEventResponse.bind(userEvent);
         TimeSheetResponse.TimeEntryResponse timeEntry1 = new TimeSheetResponse.TimeEntryResponse(
@@ -374,7 +383,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user,
-                user
+                user,
+                user.getOrganization()
         );
         final UserEvent userEvent2 = new UserEvent(
                 2L,
@@ -384,7 +394,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user2,
-                user2
+                user2,
+                user2.getOrganization()
         );
         UserEventResponse userEventResponse = UserEventResponse.bind(userEvent);
         UserEventResponse userEventResponse2 = UserEventResponse.bind(userEvent2);
@@ -464,7 +475,8 @@ class WeekUtilsTest {
                 "",
                 EventType.PERSONAL,
                 user,
-                user
+                user,
+                user.getOrganization()
         );
         UserEventResponse userEventResponse = UserEventResponse.bind(userEvent);
         assertEquals(4L, WeekUtils.getWorkingHoursForASpecificDay(date, user.getId(), Collections.emptyList(), List.of(userEventResponse)));


### PR DESCRIPTION
To test: Check DB , for "organisation_id" field in "user_events" 
When you create new User-Event, then in table of "user_events", organisation_id should be added and it is derived from creators organisation