### PR TITLE
Fix Sidebar menu to not display user tab if we're not admin

### DIFF
--- a/frontend/src/components/MenuSidebar/MenuSidebar.js
+++ b/frontend/src/components/MenuSidebar/MenuSidebar.js
@@ -63,12 +63,12 @@ const MenuSidebar = (props) => {
           <span>Projects</span>
         </Link>
       </Menu.Item>
-      <Menu.Item className="tk_MenuItem" key="/users">
+      {isAdmin && <Menu.Item className="tk_MenuItem" key="/users">
         <Link id="linkUsers" to="/users">
           <TeamOutlined/>
           <span>Users</span>
         </Link>
-      </Menu.Item>
+      </Menu.Item>}
       <Menu.Item className="tk_MenuItem" key="/events">
         <Link id="linkEvents" to="/events">
           <CalendarOutlined/>


### PR DESCRIPTION
* fix, cacher le lien de l'onglet user pour un utilisateur n'ayant pas le role admin